### PR TITLE
Add basic `git init` functionality

### DIFF
--- a/src/subcommand/init_subcommand.cpp
+++ b/src/subcommand/init_subcommand.cpp
@@ -1,19 +1,23 @@
+#include <filesystem>
 #include "init_subcommand.hpp"
-
-//#include "../wrapper/repository_wrapper.hpp"
+#include "../wrapper/repository_wrapper.hpp"
 
 InitSubcommand::InitSubcommand(CLI::App& app)
 {
     auto *sub = app.add_subcommand("init", "Explanation of init here");
 
-    sub->add_flag("--bare", bare, "--- bare ---");
+    sub->add_flag("--bare", bare, "info about bare arg");
+
+    // If directory not specified, uses cwd.
+    sub->add_option("directory", directory, "info about directory arg")
+        ->check(CLI::ExistingDirectory | CLI::NonexistentPath)
+        ->default_val(std::filesystem::current_path());
 
     sub->callback([this]() { this->run(); });
 }
 
 void InitSubcommand::run()
 {
-    std::cout << "RUN " << bare << std::endl;
-    //RepositoryWrapper repo;
-    //repo.init(bare);
+    RepositoryWrapper repo;
+    repo.init(directory, bare);
 }

--- a/src/subcommand/init_subcommand.hpp
+++ b/src/subcommand/init_subcommand.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include "base_subcommand.hpp"
 
 class InitSubcommand : public BaseSubcommand
@@ -10,4 +11,5 @@ public:
 
 private:
     bool bare;
+    std::string directory;
 };

--- a/src/wrapper/repository_wrapper.cpp
+++ b/src/wrapper/repository_wrapper.cpp
@@ -15,15 +15,8 @@ RepositoryWrapper::~RepositoryWrapper()
     }
 }
 
-void RepositoryWrapper::init(bool bare)
+void RepositoryWrapper::init(const std::string& directory, bool bare)
 {
-    std::cout << "repo init - start" << std::endl;
-
-    // what if it is already initialised???
-
-    // convert error code to exception
-    std::string path = "repo";
-    throwIfError(git_repository_init(&_repo, path.c_str(), bare));
-
-    std::cout << "repo init - end " << std::endl;
+    // what if it is already initialised?  Throw exception or delete and recreate?
+    throwIfError(git_repository_init(&_repo, directory.c_str(), bare));
 }

--- a/src/wrapper/repository_wrapper.hpp
+++ b/src/wrapper/repository_wrapper.hpp
@@ -9,7 +9,7 @@ public:
 
     virtual ~RepositoryWrapper();
 
-    void init(bool bare);
+    void init(const std::string& directory, bool bare);
 
 private:
     git_repository *_repo;

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,17 @@
+import os
+from pathlib import Path
+import pytest
+
+
+# Fixture to run test in current tmp_path
+@pytest.fixture
+def run_in_tmp_path(tmp_path):
+    original_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    yield
+    os.chdir(original_cwd)
+
+
+@pytest.fixture(scope='session')
+def git2cpp_path():
+    return Path(__file__).parent.parent / 'build' / 'git2cpp'

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -1,15 +1,19 @@
+import pytest
 import subprocess
 
-def test_version():
-    cmd = ['build/git2cpp', '-v']
+
+@pytest.mark.parametrize("arg", ['-v', '--version'])
+def test_version(arg):
+    cmd = ['build/git2cpp', arg]
     p = subprocess.run(cmd, capture_output=True)
     assert p.returncode == 0
-    assert len(p.stderr) == 0
+    assert p.stderr == b''
     assert p.stdout.startswith(b'git2cpp ')
 
-def test_unknown_option():
+
+def test_error_on_unknown_option():
     cmd = ['build/git2cpp', '--unknown']
     p = subprocess.run(cmd, capture_output=True)
-    #assert p.returncode == 1
-    assert len(p.stdout) == 0
+    assert p.returncode == 1
+    assert p.stdout == b''
     assert p.stderr.startswith(b"The following argument was not expected: --unknown")

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -3,16 +3,16 @@ import subprocess
 
 
 @pytest.mark.parametrize("arg", ['-v', '--version'])
-def test_version(arg):
-    cmd = ['build/git2cpp', arg]
+def test_version(git2cpp_path, arg):
+    cmd = [git2cpp_path, arg]
     p = subprocess.run(cmd, capture_output=True)
     assert p.returncode == 0
     assert p.stderr == b''
     assert p.stdout.startswith(b'git2cpp ')
 
 
-def test_error_on_unknown_option():
-    cmd = ['build/git2cpp', '--unknown']
+def test_error_on_unknown_option(git2cpp_path):
+    cmd = [git2cpp_path, '--unknown']
     p = subprocess.run(cmd, capture_output=True)
     assert p.returncode == 1
     assert p.stdout == b''

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -1,0 +1,67 @@
+import os
+from pathlib import Path
+import pytest
+import subprocess
+
+
+# Fixture to run test in current tmp_path
+@pytest.fixture
+def run_in_tmp_path(tmp_path):
+    original_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    yield
+    os.chdir(original_cwd)
+
+
+def test_init_in_directory(tmp_path):
+    # tmp_path exists and is empty.
+    assert list(tmp_path.iterdir()) == []
+
+    cmd = ['/Users/iant/github/git2cpp/build/git2cpp', 'init', '--bare', str(tmp_path)]
+    p = subprocess.run(cmd, capture_output=True)
+    assert p.returncode == 0
+    assert p.stdout == b''
+    assert p.stderr == b''
+
+    assert sorted(map(lambda path: path.name, tmp_path.iterdir())) == [
+        'HEAD', 'config', 'description', 'hooks', 'info', 'objects', 'refs'
+    ]
+
+    # TODO: check this is a valid git repo
+
+
+def test_init_in_cwd(tmp_path, run_in_tmp_path):
+    # tmp_path exists and is empty.
+    assert list(tmp_path.iterdir()) == []
+    assert Path.cwd() == tmp_path
+
+    cmd = ['/Users/iant/github/git2cpp/build/git2cpp', 'init', '--bare']
+    p = subprocess.run(cmd, capture_output=True)
+    assert p.returncode == 0
+    assert p.stdout == b''
+    assert p.stderr == b''
+
+    assert sorted(map(lambda path: path.name, tmp_path.iterdir())) == [
+        'HEAD', 'config', 'description', 'hooks', 'info', 'objects', 'refs'
+    ]
+
+    # TODO: check this is a valid git repo
+
+
+# TODO: Test without bare flag.
+
+
+def test_error_on_unknown_option():
+    cmd = ['build/git2cpp', 'init', '--unknown']
+    p = subprocess.run(cmd, capture_output=True)
+    assert p.returncode == 1
+    assert p.stdout == b''
+    assert p.stderr.startswith(b"The following argument was not expected: --unknown")
+
+
+def test_error_on_repeated_directory():
+    cmd = ['build/git2cpp', 'init', 'abc', 'def']
+    p = subprocess.run(cmd, capture_output=True)
+    assert p.returncode == 1
+    assert p.stdout == b''
+    assert p.stderr.startswith(b"The following argument was not expected: def")

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -1,23 +1,12 @@
-import os
 from pathlib import Path
-import pytest
 import subprocess
 
 
-# Fixture to run test in current tmp_path
-@pytest.fixture
-def run_in_tmp_path(tmp_path):
-    original_cwd = os.getcwd()
-    os.chdir(tmp_path)
-    yield
-    os.chdir(original_cwd)
-
-
-def test_init_in_directory(tmp_path):
+def test_init_in_directory(git2cpp_path, tmp_path):
     # tmp_path exists and is empty.
     assert list(tmp_path.iterdir()) == []
 
-    cmd = ['/Users/iant/github/git2cpp/build/git2cpp', 'init', '--bare', str(tmp_path)]
+    cmd = [git2cpp_path, 'init', '--bare', str(tmp_path)]
     p = subprocess.run(cmd, capture_output=True)
     assert p.returncode == 0
     assert p.stdout == b''
@@ -30,12 +19,12 @@ def test_init_in_directory(tmp_path):
     # TODO: check this is a valid git repo
 
 
-def test_init_in_cwd(tmp_path, run_in_tmp_path):
+def test_init_in_cwd(git2cpp_path, tmp_path, run_in_tmp_path):
     # tmp_path exists and is empty.
     assert list(tmp_path.iterdir()) == []
     assert Path.cwd() == tmp_path
 
-    cmd = ['/Users/iant/github/git2cpp/build/git2cpp', 'init', '--bare']
+    cmd = [git2cpp_path, 'init', '--bare']
     p = subprocess.run(cmd, capture_output=True)
     assert p.returncode == 0
     assert p.stdout == b''
@@ -51,16 +40,16 @@ def test_init_in_cwd(tmp_path, run_in_tmp_path):
 # TODO: Test without bare flag.
 
 
-def test_error_on_unknown_option():
-    cmd = ['build/git2cpp', 'init', '--unknown']
+def test_error_on_unknown_option(git2cpp_path):
+    cmd = [git2cpp_path, 'init', '--unknown']
     p = subprocess.run(cmd, capture_output=True)
     assert p.returncode == 1
     assert p.stdout == b''
     assert p.stderr.startswith(b"The following argument was not expected: --unknown")
 
 
-def test_error_on_repeated_directory():
-    cmd = ['build/git2cpp', 'init', 'abc', 'def']
+def test_error_on_repeated_directory(git2cpp_path):
+    cmd = [git2cpp_path, 'init', 'abc', 'def']
     p = subprocess.run(cmd, capture_output=True)
     assert p.returncode == 1
     assert p.stdout == b''


### PR DESCRIPTION
Add some basic support for `git init` for a directory, with and without the `--bare` flag. Not fully tested, but enough to start on the workflow for emscripten-forge and the JupyterLite terminal (issue #3).