### PR TITLE
Print version without help information

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char** argv)
             std::cout << "git2cpp version " << GIT2CPP_VERSION_STRING << " (libgit2 " << LIBGIT2_VERSION << ")" << std::endl;
         }
 
-        if (app.get_subcommands().size() == 0)
+        if (app.get_subcommands().size() == 0 && !version)
         {
             std::cout << app.help() << std::endl;
         }

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -8,7 +8,8 @@ def test_version(git2cpp_path, arg):
     p = subprocess.run(cmd, capture_output=True)
     assert p.returncode == 0
     assert p.stderr == b''
-    assert p.stdout.startswith(b'git2cpp ')
+    assert p.stdout.startswith(b'git2cpp version ')
+    assert p.stdout.count(b'\n') == 1
 
 
 def test_error_on_unknown_option(git2cpp_path):


### PR DESCRIPTION
This fixes the printing of version information. Before this PR it also prints the help information:
```bash
$ ./git2cpp -v
git2cpp version 0.0.2 (libgit2 1.9.1)
Git using C++ wrapper of libgit2 


./git2cpp [OPTIONS] [SUBCOMMAND]


OPTIONS:
  -h,     --help              Print this help message and exit 
  -v,     --version           Show version 

SUBCOMMANDS:
  init                        Explanation of init here 
  status                      Show modified files in working directory, staged for your next 
                              commit 
  add                         Add file contents to the index 
  branch                      List, create or delete branches 
  checkout                    Switch branches or restore working tree files 
  clone                       Clone a directory into a new repository 
```
After this fix just the version information is printed:
```bash
$ ./git2cpp -v
git2cpp version 0.0.2 (libgit2 1.9.1)
```

Fixes #26.