### PR TITLE
Fix printing of help and version info - attempt 2

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,8 +42,7 @@ int main(int argc, char** argv)
         {
             std::cout << "git2cpp version " << GIT2CPP_VERSION_STRING << " (libgit2 " << LIBGIT2_VERSION << ")" << std::endl;
         }
-
-        if (app.get_subcommands().size() == 0 && !version)
+        else if (app.get_subcommands().size() == 0)
         {
             std::cout << app.help() << std::endl;
         }


### PR DESCRIPTION
My fix in #27 wasn't correct.

Using `!version` to check if the version flag is specified is not correct as `version` is a pointer. It could be `!(*version)` instead but I am not prepared to use that, or the better `version->count()`. However it is better to just use an `else` of the previous `if (version->count())` so this is what I have done.