### PR TITLE
Add return codes check for subprocesses in tests

### DIFF
--- a/test/test_add.py
+++ b/test/test_add.py
@@ -19,10 +19,12 @@ def test_add(xtl_clone, git2cpp_path, all_flag):
         cmd_add.append(all_flag)
     else:
         cmd_add.append("mook_file.txt")
-    subprocess.run(cmd_add, cwd=working_dir, text=True)
+    p_add = subprocess.run(cmd_add, cwd=working_dir, text=True)
+    assert p_add.returncode == 0
 
     cmd_status = [git2cpp_path, 'status', "--long"]
     p_status = subprocess.run(cmd_status, cwd=working_dir, capture_output=True, text=True)
+    assert p_status.returncode == 0
 
     assert "Changes to be committed" in p_status.stdout
     assert "new file" in p_status.stdout

--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -9,17 +9,21 @@ working_dir = 'test/data/xtl'
 def test_branch_list(xtl_clone, git2cpp_path):
     cmd = [git2cpp_path, 'branch']
     p = subprocess.run(cmd, capture_output=True, cwd=working_dir, text=True)
+    assert p.returncode == 0
     assert(p.stdout == '* master\n')
 
 
 def test_branch_create_delete(xtl_clone, git2cpp_path):
     create_cmd = [git2cpp_path, 'branch', 'foregone']
-    subprocess.run(create_cmd, capture_output=True, cwd=working_dir, text=True)
+    p_create = subprocess.run(create_cmd, capture_output=True, cwd=working_dir, text=True)
+    assert p_create.returncode == 0
     list_cmd = [git2cpp_path, 'branch']
-    p = subprocess.run(list_cmd, capture_output=True, cwd=working_dir, text=True)
-    assert(p.stdout == '  foregone\n* master\n')
+    p_list = subprocess.run(list_cmd, capture_output=True, cwd=working_dir, text=True)
+    assert p_list.returncode == 0
+    assert(p_list.stdout == '  foregone\n* master\n')
 
     del_cmd = [git2cpp_path, 'branch', '-d', 'foregone']
     subprocess.run(del_cmd, capture_output=True, cwd=working_dir, text=True)
-    p2 = subprocess.run(list_cmd, capture_output=True, cwd=working_dir, text=True)
-    assert(p2.stdout == '* master\n')
+    p_list2 = subprocess.run(list_cmd, capture_output=True, cwd=working_dir, text=True)
+    assert p_list2.returncode == 0
+    assert(p_list2.stdout == '* master\n')

--- a/test/test_checkout.py
+++ b/test/test_checkout.py
@@ -8,35 +8,44 @@ working_dir = 'test/data/xtl'
 
 def test_checkout(xtl_clone, git2cpp_path):
     create_cmd = [git2cpp_path, 'branch', 'foregone']
-    subprocess.run(create_cmd, capture_output=True, cwd=working_dir, text=True)
+    p_create = subprocess.run(create_cmd, capture_output=True, cwd=working_dir, text=True)
+    assert p_create.returncode == 0
 
     checkout_cmd = [git2cpp_path, 'checkout', 'foregone']
-    p = subprocess.run(checkout_cmd, capture_output=True, cwd=working_dir, text=True)
-    assert(p.stdout == '');
+    p_checkout = subprocess.run(checkout_cmd, capture_output=True, cwd=working_dir, text=True)
+    assert p_checkout.returncode == 0
+    assert(p_checkout.stdout == '');
 
     branch_cmd = [git2cpp_path, 'branch']
-    p2 = subprocess.run(branch_cmd, capture_output=True, cwd=working_dir, text=True)
-    assert(p2.stdout == '* foregone\n  master\n')
+    p_branch = subprocess.run(branch_cmd, capture_output=True, cwd=working_dir, text=True)
+    assert p_branch.returncode == 0
+    assert(p_branch.stdout == '* foregone\n  master\n')
 
     checkout_cmd[2] = 'master'
-    subprocess.run(checkout_cmd, capture_output=True, cwd=working_dir, text=True)
+    p_checkout2 = subprocess.run(checkout_cmd, capture_output=True, cwd=working_dir, text=True)
+    assert p_checkout2.returncode == 0
 
     del_cmd = [git2cpp_path, 'branch', '-d', 'foregone']
-    subprocess.run(del_cmd, cwd=working_dir, text=True)
+    p_del = subprocess.run(del_cmd, cwd=working_dir, text=True)
+    assert p_del.returncode == 0
 
 
 def test_checkout_b(xtl_clone, git2cpp_path):
     checkout_cmd = [git2cpp_path, 'checkout', '-b', 'foregone']
-    p = subprocess.run(checkout_cmd, capture_output=True, cwd=working_dir, text=True)
-    assert(p.stdout == '');
+    p_checkout = subprocess.run(checkout_cmd, capture_output=True, cwd=working_dir, text=True)
+    assert p_checkout.returncode == 0
+    assert(p_checkout.stdout == '');
 
     branch_cmd = [git2cpp_path, 'branch']
-    p2 = subprocess.run(branch_cmd, capture_output=True, cwd=working_dir, text=True)
-    assert(p2.stdout == '* foregone\n  master\n')
+    p_branch = subprocess.run(branch_cmd, capture_output=True, cwd=working_dir, text=True)
+    assert p_branch.returncode == 0
+    assert(p_branch.stdout == '* foregone\n  master\n')
 
     checkout_cmd.remove('-b')
     checkout_cmd[2] = 'master'
-    subprocess.run(checkout_cmd, cwd=working_dir, text=True)
+    p_checkout2 = subprocess.run(checkout_cmd, cwd=working_dir, text=True)
+    assert p_checkout2.returncode == 0
 
     del_cmd = [git2cpp_path, 'branch', '-d', 'foregone']
-    subprocess.run(del_cmd, cwd=working_dir, text=True)
+    p_del = subprocess.run(del_cmd, cwd=working_dir, text=True)
+    assert p_del.returncode == 0

--- a/test/test_clone.py
+++ b/test/test_clone.py
@@ -9,10 +9,12 @@ def test_clone(git2cpp_path):
     working_dir = 'test/data'
 
     clone_cmd = [git2cpp_path, 'clone', url]
-    subprocess.run(clone_cmd, capture_output=True, cwd = working_dir, text=True)
+    p_clone = subprocess.run(clone_cmd, capture_output=True, cwd = working_dir, text=True)
+    assert p_clone.returncode == 0
 
     assert os.path.exists(working_dir + '/xtl')
     assert os.path.exists(working_dir + '/xtl/include')
 
     cleanup_cmd = ['rm', '-rf', 'xtl']
-    subprocess.run(cleanup_cmd, capture_output=True, cwd = working_dir, text=True)
+    p_cleanup = subprocess.run(cleanup_cmd, capture_output=True, cwd = working_dir, text=True)
+    assert p_cleanup.returncode == 0

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -12,18 +12,20 @@ def test_commit(xtl_clone, git_config, git2cpp_path, monkeypatch, all_flag):
         pass
 
     cmd_add = [git2cpp_path, 'add', "mook_file.txt"]
-    subprocess.run(cmd_add, cwd=working_dir, text=True)
+    p_add = subprocess.run(cmd_add, cwd=working_dir, text=True)
+    assert p_add.returncode == 0
 
     cmd_status = [git2cpp_path, 'status', "--long"]
     p_status = subprocess.run(cmd_status, capture_output=True, cwd=working_dir, text=True)
-
+    assert p_status.returncode == 0
     assert "Changes to be committed" in p_status.stdout
     assert "new file" in p_status.stdout
 
     cmd_commit = [git2cpp_path, 'commit', "-m", "test commit"]
-    subprocess.run(cmd_commit, cwd=working_dir, text=True)
+    p_commit = subprocess.run(cmd_commit, cwd=working_dir, text=True)
+    assert p_commit.returncode == 0
 
     cmd_status_2 = [git2cpp_path, 'status', "--long"]
     p_status_2 = subprocess.run(cmd_status_2, capture_output=True, cwd=working_dir, text=True)
-
+    assert p_status_2.returncode == 0
     assert "mook_file" not in p_status_2.stdout

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -24,6 +24,7 @@ def test_status_new_file(xtl_clone, git2cpp_path, short_flag, long_flag):
     if long_flag != "":
         cmd.append(long_flag)
     p = subprocess.run(cmd, capture_output=True, cwd=working_dir, text=True)
+    assert p.returncode == 0
 
     if (long_flag == "--long") or ((long_flag == "") & (short_flag == "")):
         assert "On branch master" in p.stdout
@@ -47,7 +48,8 @@ def test_status_add_file(xtl_clone, git2cpp_path, short_flag, long_flag):
     os.remove("./test/data/xtl/README.md")   # Changes to be committed / deleted
 
     cmd_add = [git2cpp_path, 'add', "--all"]
-    subprocess.run(cmd_add, cwd=working_dir, text=True)
+    p = subprocess.run(cmd_add, cwd=working_dir, text=True)
+    assert p.returncode == 0
 
     cmd_status = [git2cpp_path, 'status']
     if short_flag != "":


### PR DESCRIPTION
Add ```returncode``` check for ```subprocess``` in tests.
Fix #33 