### PR TITLE
Use of pytest fixture tmp_path in all tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -17,17 +17,16 @@ def git2cpp_path():
     return Path(__file__).parent.parent / 'build' / 'git2cpp'
 
 @pytest.fixture
-def xtl_clone(git2cpp_path):
+def xtl_clone(git2cpp_path, tmp_path, run_in_tmp_path):
     url = 'https://github.com/xtensor-stack/xtl.git'
-    clone_working_dir = 'test/data'
-
     clone_cmd = [git2cpp_path, 'clone', url]
-    subprocess.run(clone_cmd, capture_output=True, cwd = clone_working_dir, text=True)
+    subprocess.run(clone_cmd, capture_output=True, cwd = tmp_path, text=True)
 
+    # remove what's following ?
     yield
 
     cleanup_cmd = ['rm', '-rf', 'xtl']
-    subprocess.run(cleanup_cmd, capture_output=True, cwd = clone_working_dir, text=True)
+    subprocess.run(cleanup_cmd, capture_output=True, cwd = tmp_path, text=True)
 
 @pytest.fixture
 def git_config(monkeypatch):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -22,12 +22,6 @@ def xtl_clone(git2cpp_path, tmp_path, run_in_tmp_path):
     clone_cmd = [git2cpp_path, 'clone', url]
     subprocess.run(clone_cmd, capture_output=True, cwd = tmp_path, text=True)
 
-    # remove what's following ?
-    yield
-
-    cleanup_cmd = ['rm', '-rf', 'xtl']
-    subprocess.run(cleanup_cmd, capture_output=True, cwd = tmp_path, text=True)
-
 @pytest.fixture
 def git_config(monkeypatch):
     monkeypatch.setenv("GIT_AUTHOR_NAME", "Jane Doe")

--- a/test/test_add.py
+++ b/test/test_add.py
@@ -4,26 +4,27 @@ import subprocess
 import pytest
 
 
-working_dir = 'test/data/xtl'
-
 @pytest.mark.parametrize("all_flag", ["", "-A", "--all", "--no-ignore-removal"])
-def test_add(xtl_clone, git2cpp_path, all_flag):
-    with open("./test/data/xtl/mook_file.txt", "x"):
-        pass
+def test_add(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path, all_flag):
+    assert (tmp_path / "xtl").exists()
+    xtl_path = tmp_path / "xtl"
 
-    with open("./test/data/xtl/mook_file_2.txt", "x"):
-        pass
+    p = xtl_path / "mook_file.txt"
+    p.write_text('')
+
+    p2 = xtl_path / "mook_file_2.txt"
+    p2.write_text('')
 
     cmd_add = [git2cpp_path, 'add']
     if all_flag != "":
         cmd_add.append(all_flag)
     else:
         cmd_add.append("mook_file.txt")
-    p_add = subprocess.run(cmd_add, cwd=working_dir, text=True)
+    p_add = subprocess.run(cmd_add, cwd=xtl_path, text=True)
     assert p_add.returncode == 0
 
     cmd_status = [git2cpp_path, 'status', "--long"]
-    p_status = subprocess.run(cmd_status, cwd=working_dir, capture_output=True, text=True)
+    p_status = subprocess.run(cmd_status, cwd=xtl_path, capture_output=True, text=True)
     assert p_status.returncode == 0
 
     assert "Changes to be committed" in p_status.stdout
@@ -32,9 +33,3 @@ def test_add(xtl_clone, git2cpp_path, all_flag):
         assert "Untracked files" not in p_status.stdout
     else:
         assert "Untracked files" in p_status.stdout
-
-    os.remove("./test/data/xtl/mook_file.txt")
-    os.remove("./test/data/xtl/mook_file_2.txt")
-
-    # undo the add, to leave the test directory at the end the same as it was at the start
-    subprocess.run(cmd_add, cwd=working_dir, capture_output=True, text=True)

--- a/test/test_add.py
+++ b/test/test_add.py
@@ -5,7 +5,7 @@ import pytest
 
 
 @pytest.mark.parametrize("all_flag", ["", "-A", "--all", "--no-ignore-removal"])
-def test_add(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path, all_flag):
+def test_add(xtl_clone, git2cpp_path, tmp_path, all_flag):
     assert (tmp_path / "xtl").exists()
     xtl_path = tmp_path / "xtl"
 

--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -5,24 +5,33 @@ import pytest
 
 
 def test_branch_list(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path):
+    assert (tmp_path / "xtl").exists()
+    xtl_path = tmp_path / "xtl"
+
     cmd = [git2cpp_path, 'branch']
-    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
+    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True)
     assert p.returncode == 0
     assert(p.stdout == '* master\n')
 
 
 def test_branch_create_delete(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path):
+    assert (tmp_path / "xtl").exists()
+    xtl_path = tmp_path / "xtl"
+
     create_cmd = [git2cpp_path, 'branch', 'foregone']
-    p_create = subprocess.run(create_cmd, capture_output=True, cwd=tmp_path, text=True)
+    p_create = subprocess.run(create_cmd, capture_output=True, cwd=xtl_path, text=True)
     assert p_create.returncode == 0
 
     list_cmd = [git2cpp_path, 'branch']
-    p_list = subprocess.run(list_cmd, capture_output=True, cwd=tmp_path, text=True)
+    p_list = subprocess.run(list_cmd, capture_output=True, cwd=xtl_path, text=True)
     assert p_list.returncode == 0
     assert(p_list.stdout == '  foregone\n* master\n')
 
+    # Problem of right for "delete"? Maybe need a -D instead of -d
     del_cmd = [git2cpp_path, 'branch', '-d', 'foregone']
-    subprocess.run(del_cmd, capture_output=True, cwd=tmp_path, text=True)
-    p_list2 = subprocess.run(list_cmd, capture_output=True, cwd=tmp_path, text=True)
+    p_del = subprocess.run(del_cmd, capture_output=True, cwd=tmp_path, text=True)
+    assert p_del.returncode == 0
+
+    p_list2 = subprocess.run(list_cmd, capture_output=True, cwd=xtl_path, text=True)
     assert p_list2.returncode == 0
     assert(p_list2.stdout == '* master\n')

--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -28,7 +28,7 @@ def test_branch_create_delete(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path
     assert(p_list.stdout == '  foregone\n* master\n')
 
     # Problem of right for "delete"? Maybe need a -D instead of -d
-    del_cmd = [git2cpp_path, 'branch', '-d', '-f', 'foregone']
+    del_cmd = [git2cpp_path, 'branch', '-d', 'foregone']
     p_del = subprocess.run(del_cmd, capture_output=True, cwd=xtl_path, text=True)
     assert p_del.returncode == 0
 

--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -4,26 +4,25 @@ import subprocess
 import pytest
 
 
-working_dir = 'test/data/xtl'
-
-def test_branch_list(xtl_clone, git2cpp_path):
+def test_branch_list(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path):
     cmd = [git2cpp_path, 'branch']
-    p = subprocess.run(cmd, capture_output=True, cwd=working_dir, text=True)
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
     assert(p.stdout == '* master\n')
 
 
-def test_branch_create_delete(xtl_clone, git2cpp_path):
+def test_branch_create_delete(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path):
     create_cmd = [git2cpp_path, 'branch', 'foregone']
-    p_create = subprocess.run(create_cmd, capture_output=True, cwd=working_dir, text=True)
+    p_create = subprocess.run(create_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_create.returncode == 0
+
     list_cmd = [git2cpp_path, 'branch']
-    p_list = subprocess.run(list_cmd, capture_output=True, cwd=working_dir, text=True)
+    p_list = subprocess.run(list_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_list.returncode == 0
     assert(p_list.stdout == '  foregone\n* master\n')
 
     del_cmd = [git2cpp_path, 'branch', '-d', 'foregone']
-    subprocess.run(del_cmd, capture_output=True, cwd=working_dir, text=True)
-    p_list2 = subprocess.run(list_cmd, capture_output=True, cwd=working_dir, text=True)
+    subprocess.run(del_cmd, capture_output=True, cwd=tmp_path, text=True)
+    p_list2 = subprocess.run(list_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_list2.returncode == 0
     assert(p_list2.stdout == '* master\n')

--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -27,7 +27,6 @@ def test_branch_create_delete(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path
     assert p_list.returncode == 0
     assert(p_list.stdout == '  foregone\n* master\n')
 
-    # Problem of right for "delete"? Maybe need a -D instead of -d
     del_cmd = [git2cpp_path, 'branch', '-d', 'foregone']
     p_del = subprocess.run(del_cmd, capture_output=True, cwd=xtl_path, text=True)
     assert p_del.returncode == 0

--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -28,8 +28,8 @@ def test_branch_create_delete(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path
     assert(p_list.stdout == '  foregone\n* master\n')
 
     # Problem of right for "delete"? Maybe need a -D instead of -d
-    del_cmd = [git2cpp_path, 'branch', '-d', 'foregone']
-    p_del = subprocess.run(del_cmd, capture_output=True, cwd=tmp_path, text=True)
+    del_cmd = [git2cpp_path, 'branch', '-d', '-f', 'foregone']
+    p_del = subprocess.run(del_cmd, capture_output=True, cwd=xtl_path, text=True)
     assert p_del.returncode == 0
 
     p_list2 = subprocess.run(list_cmd, capture_output=True, cwd=xtl_path, text=True)

--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -4,7 +4,7 @@ import subprocess
 import pytest
 
 
-def test_branch_list(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path):
+def test_branch_list(xtl_clone, git2cpp_path, tmp_path):
     assert (tmp_path / "xtl").exists()
     xtl_path = tmp_path / "xtl"
 
@@ -14,7 +14,7 @@ def test_branch_list(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path):
     assert(p.stdout == '* master\n')
 
 
-def test_branch_create_delete(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path):
+def test_branch_create_delete(xtl_clone, git2cpp_path, tmp_path):
     assert (tmp_path / "xtl").exists()
     xtl_path = tmp_path / "xtl"
 

--- a/test/test_checkout.py
+++ b/test/test_checkout.py
@@ -4,7 +4,7 @@ import subprocess
 import pytest
 
 
-def test_checkout(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path):
+def test_checkout(xtl_clone, git2cpp_path, tmp_path):
     assert (tmp_path / "xtl").exists()
     xtl_path = tmp_path / "xtl"
 
@@ -27,7 +27,7 @@ def test_checkout(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path):
     assert p_checkout2.returncode == 0
 
 
-def test_checkout_b(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path):
+def test_checkout_b(xtl_clone, git2cpp_path, tmp_path):
     assert (tmp_path / "xtl").exists()
     xtl_path = tmp_path / "xtl"
 

--- a/test/test_checkout.py
+++ b/test/test_checkout.py
@@ -4,48 +4,38 @@ import subprocess
 import pytest
 
 
-working_dir = 'test/data/xtl'
-
-def test_checkout(xtl_clone, git2cpp_path):
+def test_checkout(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path):
     create_cmd = [git2cpp_path, 'branch', 'foregone']
-    p_create = subprocess.run(create_cmd, capture_output=True, cwd=working_dir, text=True)
+    p_create = subprocess.run(create_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_create.returncode == 0
 
     checkout_cmd = [git2cpp_path, 'checkout', 'foregone']
-    p_checkout = subprocess.run(checkout_cmd, capture_output=True, cwd=working_dir, text=True)
+    p_checkout = subprocess.run(checkout_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_checkout.returncode == 0
     assert(p_checkout.stdout == '');
 
     branch_cmd = [git2cpp_path, 'branch']
-    p_branch = subprocess.run(branch_cmd, capture_output=True, cwd=working_dir, text=True)
+    p_branch = subprocess.run(branch_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_branch.returncode == 0
     assert(p_branch.stdout == '* foregone\n  master\n')
 
     checkout_cmd[2] = 'master'
-    p_checkout2 = subprocess.run(checkout_cmd, capture_output=True, cwd=working_dir, text=True)
+    p_checkout2 = subprocess.run(checkout_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_checkout2.returncode == 0
 
-    del_cmd = [git2cpp_path, 'branch', '-d', 'foregone']
-    p_del = subprocess.run(del_cmd, cwd=working_dir, text=True)
-    assert p_del.returncode == 0
 
-
-def test_checkout_b(xtl_clone, git2cpp_path):
+def test_checkout_b(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path):
     checkout_cmd = [git2cpp_path, 'checkout', '-b', 'foregone']
-    p_checkout = subprocess.run(checkout_cmd, capture_output=True, cwd=working_dir, text=True)
+    p_checkout = subprocess.run(checkout_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_checkout.returncode == 0
     assert(p_checkout.stdout == '');
 
     branch_cmd = [git2cpp_path, 'branch']
-    p_branch = subprocess.run(branch_cmd, capture_output=True, cwd=working_dir, text=True)
+    p_branch = subprocess.run(branch_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_branch.returncode == 0
     assert(p_branch.stdout == '* foregone\n  master\n')
 
     checkout_cmd.remove('-b')
     checkout_cmd[2] = 'master'
-    p_checkout2 = subprocess.run(checkout_cmd, cwd=working_dir, text=True)
+    p_checkout2 = subprocess.run(checkout_cmd, cwd=tmp_path, text=True)
     assert p_checkout2.returncode == 0
-
-    del_cmd = [git2cpp_path, 'branch', '-d', 'foregone']
-    p_del = subprocess.run(del_cmd, cwd=working_dir, text=True)
-    assert p_del.returncode == 0

--- a/test/test_checkout.py
+++ b/test/test_checkout.py
@@ -5,37 +5,43 @@ import pytest
 
 
 def test_checkout(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path):
+    assert (tmp_path / "xtl").exists()
+    xtl_path = tmp_path / "xtl"
+
     create_cmd = [git2cpp_path, 'branch', 'foregone']
-    p_create = subprocess.run(create_cmd, capture_output=True, cwd=tmp_path, text=True)
+    p_create = subprocess.run(create_cmd, capture_output=True, cwd=xtl_path, text=True)
     assert p_create.returncode == 0
 
     checkout_cmd = [git2cpp_path, 'checkout', 'foregone']
-    p_checkout = subprocess.run(checkout_cmd, capture_output=True, cwd=tmp_path, text=True)
+    p_checkout = subprocess.run(checkout_cmd, capture_output=True, cwd=xtl_path, text=True)
     assert p_checkout.returncode == 0
     assert(p_checkout.stdout == '');
 
     branch_cmd = [git2cpp_path, 'branch']
-    p_branch = subprocess.run(branch_cmd, capture_output=True, cwd=tmp_path, text=True)
+    p_branch = subprocess.run(branch_cmd, capture_output=True, cwd=xtl_path, text=True)
     assert p_branch.returncode == 0
     assert(p_branch.stdout == '* foregone\n  master\n')
 
     checkout_cmd[2] = 'master'
-    p_checkout2 = subprocess.run(checkout_cmd, capture_output=True, cwd=tmp_path, text=True)
+    p_checkout2 = subprocess.run(checkout_cmd, capture_output=True, cwd=xtl_path, text=True)
     assert p_checkout2.returncode == 0
 
 
 def test_checkout_b(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path):
+    assert (tmp_path / "xtl").exists()
+    xtl_path = tmp_path / "xtl"
+
     checkout_cmd = [git2cpp_path, 'checkout', '-b', 'foregone']
-    p_checkout = subprocess.run(checkout_cmd, capture_output=True, cwd=tmp_path, text=True)
+    p_checkout = subprocess.run(checkout_cmd, capture_output=True, cwd=xtl_path, text=True)
     assert p_checkout.returncode == 0
     assert(p_checkout.stdout == '');
 
     branch_cmd = [git2cpp_path, 'branch']
-    p_branch = subprocess.run(branch_cmd, capture_output=True, cwd=tmp_path, text=True)
+    p_branch = subprocess.run(branch_cmd, capture_output=True, cwd=xtl_path, text=True)
     assert p_branch.returncode == 0
     assert(p_branch.stdout == '* foregone\n  master\n')
 
     checkout_cmd.remove('-b')
     checkout_cmd[2] = 'master'
-    p_checkout2 = subprocess.run(checkout_cmd, cwd=tmp_path, text=True)
+    p_checkout2 = subprocess.run(checkout_cmd, cwd=xtl_path, text=True)
     assert p_checkout2.returncode == 0

--- a/test/test_checkout.py
+++ b/test/test_checkout.py
@@ -45,3 +45,7 @@ def test_checkout_b(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path):
     checkout_cmd[2] = 'master'
     p_checkout2 = subprocess.run(checkout_cmd, cwd=xtl_path, text=True)
     assert p_checkout2.returncode == 0
+
+    p_branch2 = subprocess.run(branch_cmd, capture_output=True, cwd=xtl_path, text=True)
+    assert p_branch2.returncode == 0
+    assert(p_branch2.stdout == '  foregone\n* master\n')

--- a/test/test_clone.py
+++ b/test/test_clone.py
@@ -4,17 +4,12 @@ import subprocess
 import pytest
 
 
-def test_clone(git2cpp_path):
+def test_clone(git2cpp_path, tmp_path, run_in_tmp_path):
     url = 'https://github.com/xtensor-stack/xtl.git'
-    working_dir = 'test/data'
 
     clone_cmd = [git2cpp_path, 'clone', url]
-    p_clone = subprocess.run(clone_cmd, capture_output=True, cwd = working_dir, text=True)
+    p_clone = subprocess.run(clone_cmd, capture_output=True, cwd = tmp_path, text=True)
     assert p_clone.returncode == 0
 
-    assert os.path.exists(working_dir + '/xtl')
-    assert os.path.exists(working_dir + '/xtl/include')
-
-    cleanup_cmd = ['rm', '-rf', 'xtl']
-    p_cleanup = subprocess.run(cleanup_cmd, capture_output=True, cwd = working_dir, text=True)
-    assert p_cleanup.returncode == 0
+    assert os.path.exists(os.path.join(tmp_path, 'xtl'))
+    assert os.path.exists(os.path.join(tmp_path, 'xtl/include'))

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -4,28 +4,27 @@ import subprocess
 import pytest
 
 
-working_dir = 'test/data/xtl'
-
 @pytest.mark.parametrize("all_flag", ["", "-A", "--all", "--no-ignore-removal"])
-def test_commit(xtl_clone, git_config, git2cpp_path, monkeypatch, all_flag):
-    with open("./test/data/xtl/mook_file.txt", "x"):
-        pass
+def test_commit(xtl_clone, git_config, git2cpp_path, tmp_path, run_in_tmp_path, tmp_path_factory, monkeypatch, all_flag):
+    f = tmp_path / "xtl/mook_file.txt"
+    f.write_text('')
 
     cmd_add = [git2cpp_path, 'add', "mook_file.txt"]
-    p_add = subprocess.run(cmd_add, cwd=working_dir, text=True)
+    p_add = subprocess.run(cmd_add, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     cmd_status = [git2cpp_path, 'status', "--long"]
-    p_status = subprocess.run(cmd_status, capture_output=True, cwd=working_dir, text=True)
+    p_status = subprocess.run(cmd_status, capture_output=True, cwd=tmp_path, text=True)
     assert p_status.returncode == 0
+
     assert "Changes to be committed" in p_status.stdout
     assert "new file" in p_status.stdout
 
     cmd_commit = [git2cpp_path, 'commit', "-m", "test commit"]
-    p_commit = subprocess.run(cmd_commit, cwd=working_dir, text=True)
+    p_commit = subprocess.run(cmd_commit, cwd=tmp_path, text=True)
     assert p_commit.returncode == 0
 
     cmd_status_2 = [git2cpp_path, 'status', "--long"]
-    p_status_2 = subprocess.run(cmd_status_2, capture_output=True, cwd=working_dir, text=True)
+    p_status_2 = subprocess.run(cmd_status_2, capture_output=True, cwd=tmp_path, text=True)
     assert p_status_2.returncode == 0
     assert "mook_file" not in p_status_2.stdout

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -5,7 +5,7 @@ import pytest
 
 
 @pytest.mark.parametrize("all_flag", ["", "-A", "--all", "--no-ignore-removal"])
-def test_commit(xtl_clone, git_config, git2cpp_path, tmp_path, run_in_tmp_path, tmp_path_factory, monkeypatch, all_flag):
+def test_commit(xtl_clone, git_config, git2cpp_path, tmp_path, monkeypatch, all_flag):
     assert (tmp_path / "xtl").exists()
     xtl_path = tmp_path / "xtl"
 

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -6,25 +6,28 @@ import pytest
 
 @pytest.mark.parametrize("all_flag", ["", "-A", "--all", "--no-ignore-removal"])
 def test_commit(xtl_clone, git_config, git2cpp_path, tmp_path, run_in_tmp_path, tmp_path_factory, monkeypatch, all_flag):
-    f = tmp_path / "xtl/mook_file.txt"
-    f.write_text('')
+    assert (tmp_path / "xtl").exists()
+    xtl_path = tmp_path / "xtl"
+
+    p = xtl_path / "mook_file.txt"
+    p.write_text('')
 
     cmd_add = [git2cpp_path, 'add', "mook_file.txt"]
-    p_add = subprocess.run(cmd_add, cwd=tmp_path, text=True)
+    p_add = subprocess.run(cmd_add, cwd=xtl_path, text=True)
     assert p_add.returncode == 0
 
     cmd_status = [git2cpp_path, 'status', "--long"]
-    p_status = subprocess.run(cmd_status, capture_output=True, cwd=tmp_path, text=True)
+    p_status = subprocess.run(cmd_status, capture_output=True, cwd=xtl_path, text=True)
     assert p_status.returncode == 0
 
     assert "Changes to be committed" in p_status.stdout
     assert "new file" in p_status.stdout
 
     cmd_commit = [git2cpp_path, 'commit', "-m", "test commit"]
-    p_commit = subprocess.run(cmd_commit, cwd=tmp_path, text=True)
+    p_commit = subprocess.run(cmd_commit, cwd=xtl_path, text=True)
     assert p_commit.returncode == 0
 
     cmd_status_2 = [git2cpp_path, 'status', "--long"]
-    p_status_2 = subprocess.run(cmd_status_2, capture_output=True, cwd=tmp_path, text=True)
+    p_status_2 = subprocess.run(cmd_status_2, capture_output=True, cwd=xtl_path, text=True)
     assert p_status_2.returncode == 0
     assert "mook_file" not in p_status_2.stdout

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -7,21 +7,24 @@ import pytest
 
 @pytest.mark.parametrize("short_flag", ["", "-s", "--short"])
 @pytest.mark.parametrize("long_flag", ["", "--long"])
-def test_status_new_file(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path, tmp_path_factory, short_flag, long_flag):
-    f = tmp_path / "xtl/mook_file.txt"   # Untracked files
-    f.write_text('')
+def test_status_new_file(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path, short_flag, long_flag):
+    assert (tmp_path / "xtl").exists()
+    xtl_path = tmp_path / "xtl"
 
-    fw = tmp_path / "xtl/CMakeLists.txt"   # Changes not staged for commit / modified
-    fw.write("blablabla")
+    p = xtl_path / "mook_file.txt"   # Untracked files
+    p.write_text('')
 
-    os.remove(tmp_path / "xtl/README.md")   # Changes not staged for commit / deleted
+    pw = xtl_path / "CMakeLists.txt"   # Changes not staged for commit / modified
+    pw.write_text("blablabla")
+
+    os.remove(xtl_path / "README.md")   # Changes not staged for commit / deleted
 
     cmd = [git2cpp_path, 'status']
     if short_flag != "":
         cmd.append(short_flag)
     if long_flag != "":
         cmd.append(long_flag)
-    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
+    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True)
 
     if (long_flag == "--long") or ((long_flag == "") & (short_flag == "")):
         assert "On branch master" in p.stdout

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -7,7 +7,7 @@ import pytest
 
 @pytest.mark.parametrize("short_flag", ["", "-s", "--short"])
 @pytest.mark.parametrize("long_flag", ["", "--long"])
-def test_status_new_file(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path, short_flag, long_flag):
+def test_status_new_file(xtl_clone, git2cpp_path, tmp_path, short_flag, long_flag):
     assert (tmp_path / "xtl").exists()
     xtl_path = tmp_path / "xtl"
 
@@ -41,7 +41,7 @@ def test_status_new_file(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path, sho
 
 @pytest.mark.parametrize("short_flag", ["", "-s", "--short"])
 @pytest.mark.parametrize("long_flag", ["", "--long"])
-def test_status_add_file(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path, short_flag, long_flag):
+def test_status_add_file(xtl_clone, git2cpp_path, tmp_path, short_flag, long_flag):
     assert (tmp_path / "xtl").exists()
     xtl_path = tmp_path / "xtl"
 

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -5,26 +5,23 @@ import subprocess
 import pytest
 
 
-working_dir = 'test/data/xtl'
-
 @pytest.mark.parametrize("short_flag", ["", "-s", "--short"])
 @pytest.mark.parametrize("long_flag", ["", "--long"])
-def test_status_new_file(xtl_clone, git2cpp_path, short_flag, long_flag):
-    with open("./test/data/xtl/mook_file.txt", "x"):   # Untracked files
-        pass
+def test_status_new_file(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path, tmp_path_factory, short_flag, long_flag):
+    f = tmp_path / "xtl/mook_file.txt"   # Untracked files
+    f.write_text('')
 
-    with open("./test/data/xtl/CMakeLists.txt", "a") as f:   # Changes not staged for commit / modified
-        f.write("blablabla")
+    fw = tmp_path / "xtl/CMakeLists.txt"   # Changes not staged for commit / modified
+    fw.write("blablabla")
 
-    os.remove("./test/data/xtl/README.md")   # Changes not staged for commit / deleted
+    os.remove(tmp_path / "xtl/README.md")   # Changes not staged for commit / deleted
 
     cmd = [git2cpp_path, 'status']
     if short_flag != "":
         cmd.append(short_flag)
     if long_flag != "":
         cmd.append(long_flag)
-    p = subprocess.run(cmd, capture_output=True, cwd=working_dir, text=True)
-    assert p.returncode == 0
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
 
     if (long_flag == "--long") or ((long_flag == "") & (short_flag == "")):
         assert "On branch master" in p.stdout
@@ -41,30 +38,34 @@ def test_status_new_file(xtl_clone, git2cpp_path, short_flag, long_flag):
 
 @pytest.mark.parametrize("short_flag", ["", "-s", "--short"])
 @pytest.mark.parametrize("long_flag", ["", "--long"])
-def test_status_add_file(xtl_clone, git2cpp_path, short_flag, long_flag):
-    with open("./test/data/xtl/mook_file.txt", "x"):   # Changes to be committed / new file
-        pass
+def test_status_add_file(xtl_clone, git2cpp_path, tmp_path, run_in_tmp_path, short_flag, long_flag):
+    assert (tmp_path / "xtl").exists()
+    xtl_path = tmp_path / "xtl"
 
-    os.remove("./test/data/xtl/README.md")   # Changes to be committed / deleted
+    p = xtl_path / "mook_file.txt"   # Changes to be committed / new file
+    p.write_text('')
+
+    os.remove(xtl_path / "README.md")   # Changes to be committed / deleted
 
     cmd_add = [git2cpp_path, 'add', "--all"]
-    p = subprocess.run(cmd_add, cwd=working_dir, text=True)
-    assert p.returncode == 0
+    p_add = subprocess.run(cmd_add, cwd=xtl_path, text=True)
+    assert p_add.returncode == 0
 
     cmd_status = [git2cpp_path, 'status']
     if short_flag != "":
         cmd_status.append(short_flag)
     if long_flag != "":
         cmd_status.append(long_flag)
-    p = subprocess.run(cmd_status, capture_output=True, cwd=working_dir, text=True)
+    p_status = subprocess.run(cmd_status, capture_output=True, cwd=xtl_path, text=True)
+    assert p_status.returncode == 0
 
     if (long_flag == "--long") or ((long_flag == "") & (short_flag == "")):
-        assert "Changes to be committed" in p.stdout
-        assert "Changes not staged for commit" not in p.stdout
-        assert "Untracked files" not in p.stdout
-        assert "new file" in p.stdout
-        assert "deleted" in p.stdout
+        assert "Changes to be committed" in p_status.stdout
+        assert "Changes not staged for commit" not in p_status.stdout
+        assert "Untracked files" not in p_status.stdout
+        assert "new file" in p_status.stdout
+        assert "deleted" in p_status.stdout
 
     elif short_flag in ["-s", "--short"]:
-        assert "A  " in p.stdout
-        assert "D  " in p.stdout
+        assert "A  " in p_status.stdout
+        assert "D  " in p_status.stdout


### PR DESCRIPTION
Each test is now isolated from each other and no cleanup is needed as the temporary directories are automatically cleaned.