### PR TITLE
Initialise m_bare flag in init subcommand

### DIFF
--- a/src/subcommand/init_subcommand.hpp
+++ b/src/subcommand/init_subcommand.hpp
@@ -14,6 +14,6 @@ public:
     void run();
 
 private:
-    bool m_bare;
+    bool m_bare = false;
     std::string m_directory;
 };

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -37,7 +37,29 @@ def test_init_in_cwd(git2cpp_path, tmp_path, run_in_tmp_path):
     # TODO: check this is a valid git repo
 
 
-# TODO: Test without bare flag.
+def test_init_not_bare(git2cpp_path, tmp_path):
+    # tmp_path exists and is empty.
+    assert list(tmp_path.iterdir()) == []
+
+    cmd = [git2cpp_path, 'init', '.']
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path)
+    assert p.returncode == 0
+    assert p.stdout == b''
+    assert p.stderr == b''
+
+    # Directory contains just .git directory.
+    assert sorted(map(lambda path: path.name, tmp_path.iterdir())) == ['.git']
+    # .git directory is a valid repo.
+    assert sorted(map(lambda path: path.name, (tmp_path / '.git').iterdir())) == [
+        'HEAD', 'config', 'description', 'hooks', 'info', 'objects', 'refs'
+    ]
+
+    # Would like to use `git2cpp status` but it complains that 'refs/heads/master' not found
+    cmd = [git2cpp_path, 'log']
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path)
+    assert p.returncode == 0
+    assert p.stdout == b''
+    assert p.stderr == b''
 
 
 def test_error_on_unknown_option(git2cpp_path):


### PR DESCRIPTION
Initialise `init_subcommand.m_bare` boolean flag as is done with other boolean flags passed to `cli11` subcommands. This turned out to cause a problem with the emscripten-forge build, depending on the compiler flags.