### PR TITLE
Add CI run to gather code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,4 +96,5 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: coverage.lcov
+          token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true


### PR DESCRIPTION
This PR adds a new CI run to gather code coverage of the C++ source code. This involves building the project with some specific flags and then running the `pytest` suite as normal to create output files containing coverage information. These output files are then manipulated to produce a HTML report that is uploaded as an artifact so that it can be downloaded by interested parties.

When this is working properly we can also upload the information to https://codecov.io/ so that is can be easily browsed online.

Closes #2.