### PR TITLE
Add dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - 'maintenance'
+    groups:
+      actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
This PR adds a `dependabot.yml` file so that `dependabot` will run once a week to automatically create a PR to update any github actions that have new versions available. I have also created a new `maintenance` label for this PR and the ones that `dependabot` will create.