### PR TITLE
Fix path used for wasm deployment to github pages

### DIFF
--- a/.github/workflows/deploy-wasm.yml
+++ b/.github/workflows/deploy-wasm.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          path: ./wasm/serve
+          path: ./wasm/serve/dist
 
   deploy:
     needs: build

--- a/.github/workflows/deploy-wasm.yml
+++ b/.github/workflows/deploy-wasm.yml
@@ -43,6 +43,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.ref == 'refs/heads/main'
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
The wasm deployment to github pages is broken because I changed a path in one place in the code but not in another. This PR fixes it.