### PR TITLE
Reduce use of ```xtl_clone``` in tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,10 +4,11 @@ from pathlib import Path
 
 import pytest
 
-GIT2CPP_TEST_WASM = os.getenv('GIT2CPP_TEST_WASM') == "1"
+GIT2CPP_TEST_WASM = os.getenv("GIT2CPP_TEST_WASM") == "1"
 
 if GIT2CPP_TEST_WASM:
     from .conftest_wasm import *
+
 
 # Fixture to run test in current tmp_path
 @pytest.fixture
@@ -21,9 +22,10 @@ def run_in_tmp_path(tmp_path):
 @pytest.fixture(scope="session")
 def git2cpp_path():
     if GIT2CPP_TEST_WASM:
-        return 'git2cpp'
+        return "git2cpp"
     else:
-        return Path(__file__).parent.parent / 'build' / 'git2cpp'
+        return Path(__file__).parent.parent / "build" / "git2cpp"
+
 
 @pytest.fixture
 def xtl_clone(git2cpp_path, tmp_path, run_in_tmp_path):
@@ -39,10 +41,28 @@ def commit_env_config(monkeypatch):
         "GIT_AUTHOR_NAME": "Jane Doe",
         "GIT_AUTHOR_EMAIL": "jane.doe@blabla.com",
         "GIT_COMMITTER_NAME": "Jane Doe",
-        "GIT_COMMITTER_EMAIL": "jane.doe@blabla.com"
+        "GIT_COMMITTER_EMAIL": "jane.doe@blabla.com",
     }
     for key, value in config.items():
         if GIT2CPP_TEST_WASM:
             subprocess.run(["export", f"{key}='{value}'"], check=True)
         else:
             monkeypatch.setenv(key, value)
+
+
+@pytest.fixture
+def repo_init_with_commit(commit_env_config, git2cpp_path, tmp_path, run_in_tmp_path):
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path, text=True)
+    assert p_init.returncode == 0
+
+    p = tmp_path / "initial.txt"
+    p.write_text("initial")
+
+    cmd_add = [git2cpp_path, "add", "initial.txt"]
+    p_add = subprocess.run(cmd_add, capture_output=True, cwd=tmp_path, text=True)
+    assert p_add.returncode == 0
+
+    cmd_commit = [git2cpp_path, "commit", "-m", "Initial commit"]
+    p_commit = subprocess.run(cmd_commit, capture_output=True, cwd=tmp_path, text=True)
+    assert p_commit.returncode == 0

--- a/test/test_add.py
+++ b/test/test_add.py
@@ -4,26 +4,27 @@ import pytest
 
 
 @pytest.mark.parametrize("all_flag", ["", "-A", "--all", "--no-ignore-removal"])
-def test_add(xtl_clone, git2cpp_path, tmp_path, all_flag):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_add(git2cpp_path, tmp_path, all_flag):
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
-    p = xtl_path / "mook_file.txt"
-    p.write_text('')
+    p = tmp_path / "mook_file.txt"
+    p.write_text("")
 
-    p2 = xtl_path / "mook_file_2.txt"
-    p2.write_text('')
+    p2 = tmp_path / "mook_file_2.txt"
+    p2.write_text("")
 
-    cmd_add = [git2cpp_path, 'add']
+    cmd_add = [git2cpp_path, "add"]
     if all_flag != "":
         cmd_add.append(all_flag)
     else:
         cmd_add.append("mook_file.txt")
-    p_add = subprocess.run(cmd_add, cwd=xtl_path, text=True)
+    p_add = subprocess.run(cmd_add, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
-    cmd_status = [git2cpp_path, 'status', "--long"]
-    p_status = subprocess.run(cmd_status, cwd=xtl_path, capture_output=True, text=True)
+    cmd_status = [git2cpp_path, "status", "--long"]
+    p_status = subprocess.run(cmd_status, cwd=tmp_path, capture_output=True, text=True)
     assert p_status.returncode == 0
 
     assert "Changes to be committed" in p_status.stdout
@@ -33,11 +34,12 @@ def test_add(xtl_clone, git2cpp_path, tmp_path, all_flag):
     else:
         assert "Untracked files" in p_status.stdout
 
+
 def test_add_nogit(git2cpp_path, tmp_path):
     p = tmp_path / "mook_file.txt"
-    p.write_text('')
+    p.write_text("")
 
-    cmd_add = [git2cpp_path, 'add', 'mook_file.txt']
+    cmd_add = [git2cpp_path, "add", "mook_file.txt"]
     p_add = subprocess.run(cmd_add, cwd=tmp_path, text=True, capture_output=True)
     assert p_add.returncode != 0
     assert "error: could not find repository at" in p_add.stderr

--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -3,52 +3,51 @@ import subprocess
 import pytest
 
 
-def test_branch_list(xtl_clone, git2cpp_path, tmp_path):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_branch_list(repo_init_with_commit, git2cpp_path, tmp_path):
+    assert (tmp_path / "initial.txt").exists()
 
-    cmd = [git2cpp_path, 'branch']
-    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True)
+    cmd = [git2cpp_path, "branch"]
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
-    assert(p.stdout == '* master\n')
+    assert "* ma" in p.stdout
 
 
-def test_branch_create_delete(xtl_clone, git2cpp_path, tmp_path):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_branch_create_delete(repo_init_with_commit, git2cpp_path, tmp_path):
+    assert (tmp_path / "initial.txt").exists()
 
-    create_cmd = [git2cpp_path, 'branch', 'foregone']
-    p_create = subprocess.run(create_cmd, capture_output=True, cwd=xtl_path, text=True)
+    create_cmd = [git2cpp_path, "branch", "foregone"]
+    p_create = subprocess.run(create_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_create.returncode == 0
 
-    list_cmd = [git2cpp_path, 'branch']
-    p_list = subprocess.run(list_cmd, capture_output=True, cwd=xtl_path, text=True)
+    list_cmd = [git2cpp_path, "branch"]
+    p_list = subprocess.run(list_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_list.returncode == 0
-    assert(p_list.stdout == '  foregone\n* master\n')
+    assert "  foregone\n* ma" in p_list.stdout
 
-    del_cmd = [git2cpp_path, 'branch', '-d', 'foregone']
-    p_del = subprocess.run(del_cmd, capture_output=True, cwd=xtl_path, text=True)
+    del_cmd = [git2cpp_path, "branch", "-d", "foregone"]
+    p_del = subprocess.run(del_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_del.returncode == 0
 
-    p_list2 = subprocess.run(list_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_list2 = subprocess.run(list_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_list2.returncode == 0
-    assert(p_list2.stdout == '* master\n')
+    assert "* ma" in p_list2.stdout
+
 
 def test_branch_nogit(git2cpp_path, tmp_path):
-    cmd = [git2cpp_path, 'branch']
+    cmd = [git2cpp_path, "branch"]
     p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode != 0
     assert "error: could not find repository at" in p.stderr
 
 
 def test_branch_new_repo(git2cpp_path, tmp_path, run_in_tmp_path):
-   # tmp_path exists and is empty.
+    # tmp_path exists and is empty.
     assert list(tmp_path.iterdir()) == []
 
-    cmd = [git2cpp_path, 'init']
-    p = subprocess.run(cmd, cwd = tmp_path)
+    cmd = [git2cpp_path, "init"]
+    subprocess.run(cmd, cwd=tmp_path, check=True)
 
-    branch_cmd = [git2cpp_path, 'branch']
-    p_branch = subprocess.run(branch_cmd, cwd = tmp_path)
+    branch_cmd = [git2cpp_path, "branch"]
+    p_branch = subprocess.run(branch_cmd, cwd=tmp_path)
 
     assert p_branch.returncode == 0

--- a/test/test_checkout.py
+++ b/test/test_checkout.py
@@ -3,94 +3,106 @@ import subprocess
 import pytest
 
 
-def test_checkout(xtl_clone, git2cpp_path, tmp_path):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_checkout(repo_init_with_commit, git2cpp_path, tmp_path):
+    assert (tmp_path / "initial.txt").exists()
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     create_cmd = [git2cpp_path, "branch", "foregone"]
-    p_create = subprocess.run(create_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_create = subprocess.run(create_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_create.returncode == 0
 
     checkout_cmd = [git2cpp_path, "checkout", "foregone"]
     p_checkout = subprocess.run(
-        checkout_cmd, capture_output=True, cwd=xtl_path, text=True
+        checkout_cmd, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_checkout.returncode == 0
     assert "Switched to branch 'foregone'" in p_checkout.stdout
 
     branch_cmd = [git2cpp_path, "branch"]
-    p_branch = subprocess.run(branch_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_branch = subprocess.run(branch_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_branch.returncode == 0
-    assert p_branch.stdout == "* foregone\n  master\n"
+    assert p_branch.stdout == f"* foregone\n  {default_branch}\n"
 
-    checkout_cmd[2] = "master"
+    checkout_cmd[2] = default_branch
     p_checkout2 = subprocess.run(
-        checkout_cmd, capture_output=True, cwd=xtl_path, text=True
+        checkout_cmd, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_checkout2.returncode == 0
-    assert "Switched to branch 'master'" in p_checkout2.stdout
+    assert f"Switched to branch '{default_branch}'" in p_checkout2.stdout
 
 
-def test_checkout_b(xtl_clone, git2cpp_path, tmp_path):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_checkout_b(repo_init_with_commit, git2cpp_path, tmp_path):
+    assert (tmp_path / "initial.txt").exists()
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     checkout_cmd = [git2cpp_path, "checkout", "-b", "foregone"]
     p_checkout = subprocess.run(
-        checkout_cmd, capture_output=True, cwd=xtl_path, text=True
+        checkout_cmd, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_checkout.returncode == 0
     assert "Switched to a new branch 'foregone'" in p_checkout.stdout
 
     branch_cmd = [git2cpp_path, "branch"]
-    p_branch = subprocess.run(branch_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_branch = subprocess.run(branch_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_branch.returncode == 0
-    assert p_branch.stdout == "* foregone\n  master\n"
+    assert p_branch.stdout == f"* foregone\n  {default_branch}\n"
 
     checkout_cmd.remove("-b")
-    checkout_cmd[2] = "master"
-    p_checkout2 = subprocess.run(checkout_cmd, cwd=xtl_path, text=True)
+    checkout_cmd[2] = default_branch
+    p_checkout2 = subprocess.run(checkout_cmd, cwd=tmp_path, text=True)
     assert p_checkout2.returncode == 0
 
-    p_branch2 = subprocess.run(branch_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_branch2 = subprocess.run(branch_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_branch2.returncode == 0
-    assert p_branch2.stdout == "  foregone\n* master\n"
+    assert p_branch2.stdout == f"  foregone\n* {default_branch}\n"
 
 
-def test_checkout_B_force_create(xtl_clone, git2cpp_path, tmp_path):
+def test_checkout_B_force_create(repo_init_with_commit, git2cpp_path, tmp_path):
     """Test checkout -B to force create or reset a branch"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     # Create a branch first
     create_cmd = [git2cpp_path, "branch", "resetme"]
-    p_create = subprocess.run(create_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_create = subprocess.run(create_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_create.returncode == 0
 
     # Use -B to reset it (should not fail even if branch exists)
     checkout_cmd = [git2cpp_path, "checkout", "-B", "resetme"]
     p_checkout = subprocess.run(
-        checkout_cmd, capture_output=True, cwd=xtl_path, text=True
+        checkout_cmd, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_checkout.returncode == 0
     assert "Switched to a new branch 'resetme'" in p_checkout.stdout
 
     # Verify we're on the branch
     branch_cmd = [git2cpp_path, "branch"]
-    p_branch = subprocess.run(branch_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_branch = subprocess.run(branch_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_branch.returncode == 0
     assert "* resetme" in p_branch.stdout
 
 
-def test_checkout_invalid_branch(xtl_clone, git2cpp_path, tmp_path):
+def test_checkout_invalid_branch(repo_init_with_commit, git2cpp_path, tmp_path):
     """Test that checkout fails gracefully with invalid branch name"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     # Try to checkout non-existent branch
     checkout_cmd = [git2cpp_path, "checkout", "nonexistent"]
     p_checkout = subprocess.run(
-        checkout_cmd, capture_output=True, cwd=xtl_path, text=True
+        checkout_cmd, capture_output=True, cwd=tmp_path, text=True
     )
 
     # Should fail with error message
@@ -98,64 +110,70 @@ def test_checkout_invalid_branch(xtl_clone, git2cpp_path, tmp_path):
     assert "error: could not resolve pathspec 'nonexistent'" in p_checkout.stderr
 
 
-def test_checkout_with_unstaged_changes(xtl_clone, git2cpp_path, tmp_path):
+def test_checkout_with_unstaged_changes(repo_init_with_commit, git2cpp_path, tmp_path):
     """Test that checkout shows unstaged changes when switching branches"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    initial_file = tmp_path / "initial.txt"
+    assert (initial_file).exists()
 
     # Create a new branch
     create_cmd = [git2cpp_path, "branch", "newbranch"]
-    p_create = subprocess.run(create_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_create = subprocess.run(create_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_create.returncode == 0
 
     # Modify a file (unstaged change)
-    readme_path = xtl_path / "README.md"
-    readme_path.write_text("Modified content")
+    initial_file.write_text("Modified content")
 
     # Checkout - should succeed and show the modified file status
     checkout_cmd = [git2cpp_path, "checkout", "newbranch"]
     p_checkout = subprocess.run(
-        checkout_cmd, capture_output=True, cwd=xtl_path, text=True
+        checkout_cmd, capture_output=True, cwd=tmp_path, text=True
     )
 
     # Should succeed and show status
     assert p_checkout.returncode == 0
-    assert " M README.md" in p_checkout.stdout
+    assert " M initial.txt" in p_checkout.stdout
     assert "Switched to branch 'newbranch'" in p_checkout.stdout
 
 
 @pytest.mark.parametrize("force_flag", ["", "-f", "--force"])
 def test_checkout_refuses_overwrite(
-    xtl_clone, commit_env_config, git2cpp_path, tmp_path, force_flag
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path, force_flag
 ):
     """Test that checkout refuses to switch when local changes would be overwritten, and switches when using --force"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    initial_file = tmp_path / "initial.txt"
+    assert (initial_file).exists()
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     # Create a new branch and switch to it
     create_cmd = [git2cpp_path, "checkout", "-b", "newbranch"]
-    p_create = subprocess.run(create_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_create = subprocess.run(create_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_create.returncode == 0
 
-    # Modify README.md and commit it on newbranch
-    readme_path = xtl_path / "README.md"
-    readme_path.write_text("Content on newbranch")
+    # Modify initial.txt and commit it on newbranch
+    initial_file.write_text("Content on newbranch")
 
-    add_cmd = [git2cpp_path, "add", "README.md"]
-    subprocess.run(add_cmd, cwd=xtl_path, text=True)
+    add_cmd = [git2cpp_path, "add", "initial.txt"]
+    subprocess.run(add_cmd, cwd=tmp_path, text=True)
 
     commit_cmd = [git2cpp_path, "commit", "-m", "Change on newbranch"]
-    subprocess.run(commit_cmd, cwd=xtl_path, text=True)
+    subprocess.run(commit_cmd, cwd=tmp_path, text=True)
 
-    # Switch back to master
-    checkout_master_cmd = [git2cpp_path, "checkout", "master"]
-    p_master = subprocess.run(
-        checkout_master_cmd, capture_output=True, cwd=xtl_path, text=True
+    # Switch back to default branch
+    checkout_default_cmd = [git2cpp_path, "checkout", default_branch]
+    p_default = subprocess.run(
+        checkout_default_cmd, capture_output=True, cwd=tmp_path, text=True
     )
-    assert p_master.returncode == 0
+    assert p_default.returncode == 0
 
-    # Now modify README.md locally (unstaged) on master
-    readme_path.write_text("Local modification on master")
+    # Now modify initial.txt locally (unstaged) on default branch
+    initial_file.write_text(f"Local modification on {default_branch}")
 
     # Try to checkout newbranch
     checkout_cmd = [git2cpp_path, "checkout"]
@@ -163,7 +181,7 @@ def test_checkout_refuses_overwrite(
         checkout_cmd.append(force_flag)
     checkout_cmd.append("newbranch")
     p_checkout = subprocess.run(
-        checkout_cmd, capture_output=True, cwd=xtl_path, text=True
+        checkout_cmd, capture_output=True, cwd=tmp_path, text=True
     )
 
     if force_flag == "":
@@ -172,24 +190,24 @@ def test_checkout_refuses_overwrite(
             "Your local changes to the following files would be overwritten by checkout:"
             in p_checkout.stdout
         )
-        assert "README.md" in p_checkout.stdout
+        assert "initial.txt" in p_checkout.stdout
         assert (
             "Please commit your changes or stash them before you switch branches"
             in p_checkout.stdout
         )
 
-        # Verify we're still on master (didn't switch)
+        # Verify we're still on default branch (didn't switch)
         branch_cmd = [git2cpp_path, "branch"]
         p_branch = subprocess.run(
-            branch_cmd, capture_output=True, cwd=xtl_path, text=True
+            branch_cmd, capture_output=True, cwd=tmp_path, text=True
         )
-        assert "* master" in p_branch.stdout
+        assert f"* {default_branch}" in p_branch.stdout
     else:
         assert "Switched to branch 'newbranch'" in p_checkout.stdout
 
         # Verify we switched to newbranch
         branch_cmd = [git2cpp_path, "branch"]
         p_branch = subprocess.run(
-            branch_cmd, capture_output=True, cwd=xtl_path, text=True
+            branch_cmd, capture_output=True, cwd=tmp_path, text=True
         )
         assert "* newbranch" in p_branch.stdout

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -4,38 +4,41 @@ import pytest
 
 
 @pytest.mark.parametrize("all_flag", ["", "-A", "--all", "--no-ignore-removal"])
-def test_commit(xtl_clone, commit_env_config, git2cpp_path, tmp_path, all_flag):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_commit(commit_env_config, git2cpp_path, tmp_path, all_flag):
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
-    p = xtl_path / "mook_file.txt"
+    p = tmp_path / "mook_file.txt"
     p.write_text("")
 
     cmd_add = [git2cpp_path, "add", "mook_file.txt"]
-    p_add = subprocess.run(cmd_add, cwd=xtl_path, text=True)
+    p_add = subprocess.run(cmd_add, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     cmd_status = [git2cpp_path, "status", "--long"]
-    p_status = subprocess.run(cmd_status, capture_output=True, cwd=xtl_path, text=True)
+    p_status = subprocess.run(cmd_status, capture_output=True, cwd=tmp_path, text=True)
     assert p_status.returncode == 0
 
     assert "Changes to be committed" in p_status.stdout
     assert "new file" in p_status.stdout
 
     cmd_commit = [git2cpp_path, "commit", "-m", "test commit"]
-    p_commit = subprocess.run(cmd_commit, cwd=xtl_path, text=True)
+    p_commit = subprocess.run(cmd_commit, cwd=tmp_path, text=True)
     assert p_commit.returncode == 0
 
     cmd_status_2 = [git2cpp_path, "status", "--long"]
     p_status_2 = subprocess.run(
-        cmd_status_2, capture_output=True, cwd=xtl_path, text=True
+        cmd_status_2, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_status_2.returncode == 0
     assert "mook_file" not in p_status_2.stdout
 
 
 @pytest.mark.parametrize("commit_msg", ["Added file", ""])
-def test_commit_message_via_stdin(commit_env_config, git2cpp_path, tmp_path, run_in_tmp_path, commit_msg):
+def test_commit_message_via_stdin(
+    commit_env_config, git2cpp_path, tmp_path, run_in_tmp_path, commit_msg
+):
     cmd = [git2cpp_path, "init", "."]
     p_init = subprocess.run(cmd)
     assert p_init.returncode == 0
@@ -47,7 +50,9 @@ def test_commit_message_via_stdin(commit_env_config, git2cpp_path, tmp_path, run
     assert p_add.returncode == 0
 
     cmd_commit = [git2cpp_path, "commit"]
-    p_commit = subprocess.run(cmd_commit, text=True, capture_output=True, input=commit_msg)
+    p_commit = subprocess.run(
+        cmd_commit, text=True, capture_output=True, input=commit_msg
+    )
 
     if commit_msg == "":
         # No commit message

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -54,3 +54,13 @@ def test_config_unset(git2cpp_path, tmp_path):
     p_get = subprocess.run(cmd_get, capture_output=True, cwd=tmp_path, text=True)
     assert p_get.returncode != 0
     assert p_get.stderr == "error: config value 'core.bare' was not found\n"
+
+
+def test_config_get_missing_name_exit_code(git2cpp_path, tmp_path):
+    p = subprocess.run(
+        [git2cpp_path, "config", "get"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert p.returncode == 129

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -11,51 +11,53 @@ def test_diff_nogit(git2cpp_path, tmp_path):
     assert "repository" in p.stderr.lower() or "not a git" in p.stderr.lower()
 
 
-def test_diff_working_directory(xtl_clone, git2cpp_path, tmp_path):
-    xtl_path = tmp_path / "xtl"
+def test_diff_working_directory(repo_init_with_commit, git2cpp_path, tmp_path):
+    initial_file = tmp_path / "initial.txt"
+    assert (initial_file).exists()
 
-    readme = xtl_path / "README.md"
-    original_content = readme.read_text()
-    readme.write_text(original_content + "\nNew line added")
+    original_content = initial_file.read_text()
+    initial_file.write_text(original_content + "\nNew line added")
 
     cmd = [git2cpp_path, "diff"]
-    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
-    assert "README.md" in p.stdout
-    assert "New line added" in p.stdout  # should be "+New line added"
+    assert "initial.txt" in p.stdout
+    assert "+New line added" in p.stdout
 
 
 @pytest.mark.parametrize("cached_flag", ["--cached", "--staged"])
-def test_diff_cached(xtl_clone, git2cpp_path, tmp_path, cached_flag):
-    xtl_path = tmp_path / "xtl"
+def test_diff_cached(repo_init_with_commit, git2cpp_path, tmp_path, cached_flag):
+    assert (tmp_path / "initial.txt").exists()
 
-    new_file = xtl_path / "new_file.txt"
+    new_file = tmp_path / "new_file.txt"
     new_file.write_text("Hello, world!")
 
     cmd_add = [git2cpp_path, "add", "new_file.txt"]
-    subprocess.run(cmd_add, cwd=xtl_path, check=True)
+    subprocess.run(cmd_add, cwd=tmp_path, check=True)
 
     cmd_diff = [git2cpp_path, "diff", cached_flag]
-    p_diff = subprocess.run(cmd_diff, capture_output=True, cwd=xtl_path, text=True)
+    p_diff = subprocess.run(cmd_diff, capture_output=True, cwd=tmp_path, text=True)
     assert p_diff.returncode == 0
     assert "new_file.txt" in p_diff.stdout
     assert "+Hello, world!" in p_diff.stdout
 
 
-def test_diff_two_commits(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
-    xtl_path = tmp_path / "xtl"
+def test_diff_two_commits(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
+    assert (tmp_path / "initial.txt").exists()
 
-    new_file = xtl_path / "new_file.txt"
+    new_file = tmp_path / "new_file.txt"
     new_file.write_text("Hello, world!")
 
     cmd_add = [git2cpp_path, "add", "new_file.txt"]
-    subprocess.run(cmd_add, cwd=xtl_path, check=True)
+    subprocess.run(cmd_add, cwd=tmp_path, check=True)
 
     cmd_commit = [git2cpp_path, "commit", "-m", "new commit"]
-    subprocess.run(cmd_commit, cwd=xtl_path, check=True)
+    subprocess.run(cmd_commit, cwd=tmp_path, check=True)
 
     cmd_diff = [git2cpp_path, "diff", "HEAD~1", "HEAD"]
-    p_diff = subprocess.run(cmd_diff, capture_output=True, cwd=xtl_path, text=True)
+    p_diff = subprocess.run(cmd_diff, capture_output=True, cwd=tmp_path, text=True)
     assert p_diff.returncode == 0
     assert "new_file.txt" in p_diff.stdout
     assert "+Hello, world!" in p_diff.stdout
@@ -75,208 +77,212 @@ def test_diff_no_index(git2cpp_path, tmp_path):
     assert "+Python" in p.stdout
 
 
-def test_diff_stat(xtl_clone, git2cpp_path, tmp_path):
-    xtl_path = tmp_path / "xtl"
+def test_diff_stat(repo_init_with_commit, git2cpp_path, tmp_path):
+    initial_file = tmp_path / "initial.txt"
+    assert (initial_file).exists()
 
-    readme = xtl_path / "README.md"
-    readme.write_text("Modified content\n")
+    initial_file.write_text("Modified content\n")
 
     cmd = [git2cpp_path, "diff", "--stat"]
-    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
-    assert "README.md" in p.stdout
+    assert "initial.txt" in p.stdout
     assert "1 file changed, 1 insertion(+)" in p.stdout
     assert "Modified content" not in p.stdout
 
 
-def test_diff_shortstat(xtl_clone, git2cpp_path, tmp_path):
+def test_diff_shortstat(repo_init_with_commit, git2cpp_path, tmp_path):
     """Test diff with --shortstat (last line of --stat only)"""
-    xtl_path = tmp_path / "xtl"
+    initial_file = tmp_path / "initial.txt"
+    assert (initial_file).exists()
 
-    readme = xtl_path / "README.md"
-    readme.write_text("Modified content\n")
+    initial_file.write_text("Modified content\n")
 
     cmd = [git2cpp_path, "diff", "--shortstat"]
-    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
     assert "README.md" not in p.stdout
     assert "1 file changed, 1 insertion(+)" in p.stdout
     assert "Modified content" not in p.stdout
 
 
-def test_diff_numstat(xtl_clone, git2cpp_path, tmp_path):
+def test_diff_numstat(repo_init_with_commit, git2cpp_path, tmp_path):
     """Test diff with --numstat (machine-friendly stat)"""
-    xtl_path = tmp_path / "xtl"
+    initial_file = tmp_path / "initial.txt"
+    assert (initial_file).exists()
 
-    readme = xtl_path / "README.md"
-    readme.write_text("Modified content\n")
+    initial_file.write_text("Modified content\n")
 
     cmd = [git2cpp_path, "diff", "--numstat"]
-    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
-    assert "README.md" in p.stdout
+    assert "initial.txt" in p.stdout
     assert bool(re.search("1       [0-9]*", p.stdout))
     assert "Modified content" not in p.stdout
 
 
-def test_diff_summary(xtl_clone, git2cpp_path, tmp_path):
+def test_diff_summary(repo_init_with_commit, git2cpp_path, tmp_path):
     """Test diff with --summary"""
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
-    new_file = xtl_path / "newfile.txt"
+    new_file = tmp_path / "newfile.txt"
     new_file.write_text("New content")
 
     cmd_add = [git2cpp_path, "add", "newfile.txt"]
-    subprocess.run(cmd_add, cwd=xtl_path, check=True)
+    subprocess.run(cmd_add, cwd=tmp_path, check=True)
 
     cmd = [git2cpp_path, "diff", "--cached", "--summary"]
-    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
     assert "newfile.txt" in p.stdout
     assert "+" not in p.stdout
 
 
-def test_diff_name_only(xtl_clone, git2cpp_path, tmp_path):
-    xtl_path = tmp_path / "xtl"
+def test_diff_name_only(repo_init_with_commit, git2cpp_path, tmp_path):
+    initial_file = tmp_path / "initial.txt"
+    assert (initial_file).exists()
 
-    (xtl_path / "README.md").write_text("Modified")
+    initial_file.write_text("Modified")
 
     cmd = [git2cpp_path, "diff", "--name-only"]
-    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
 
     assert p.returncode == 0
-    assert p.stdout == "README.md\n"
+    assert p.stdout == "initial.txt\n"
     assert "+" not in p.stdout
 
 
-def test_diff_name_status(xtl_clone, git2cpp_path, tmp_path):
-    xtl_path = tmp_path / "xtl"
+def test_diff_name_status(repo_init_with_commit, git2cpp_path, tmp_path):
+    initial_file = tmp_path / "initial.txt"
+    assert (initial_file).exists()
 
-    (xtl_path / "README.md").write_text("Modified")
+    initial_file.write_text("Modified")
 
     cmd = [git2cpp_path, "diff", "--name-status"]
-    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
-    assert p.stdout == "M\tREADME.md\n"
+    assert p.stdout == "M\tinitial.txt\n"
 
 
-def test_diff_raw(xtl_clone, git2cpp_path, tmp_path):
+def test_diff_raw(repo_init_with_commit, git2cpp_path, tmp_path):
     """Test diff with --raw format"""
-    xtl_path = tmp_path / "xtl"
+    initial_file = tmp_path / "initial.txt"
+    assert (initial_file).exists()
 
-    readme = xtl_path / "README.md"
-    readme.write_text("Modified")
+    initial_file.write_text("Modified")
 
     cmd = [git2cpp_path, "diff", "--raw"]
-    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
-    assert "M\tREADME.md" in p.stdout
+    assert "M\tinitial.txt" in p.stdout
     assert bool(re.search(":[0-9]*", p.stdout))
 
 
-def test_diff_reverse(xtl_clone, git2cpp_path, tmp_path):
-    xtl_path = tmp_path / "xtl"
+def test_diff_reverse(repo_init_with_commit, git2cpp_path, tmp_path):
+    initial_file = tmp_path / "initial.txt"
+    assert (initial_file).exists()
 
-    readme = xtl_path / "README.md"
-    original = readme.read_text()
-    readme.write_text(original + "\nAdded line")
+    original = initial_file.read_text()
+    initial_file.write_text(original + "\nAdded line")
 
     cmd_normal = [git2cpp_path, "diff"]
-    p_normal = subprocess.run(cmd_normal, capture_output=True, cwd=xtl_path, text=True)
+    p_normal = subprocess.run(cmd_normal, capture_output=True, cwd=tmp_path, text=True)
     assert p_normal.returncode == 0
     assert "+Added line" in p_normal.stdout
 
     cmd_reverse = [git2cpp_path, "diff", "-R"]
     p_reverse = subprocess.run(
-        cmd_reverse, capture_output=True, cwd=xtl_path, text=True
+        cmd_reverse, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_reverse.returncode == 0
     assert "-Added line" in p_reverse.stdout
 
 
 @pytest.mark.parametrize("text_flag", ["-a", "--text"])
-def test_diff_text(xtl_clone, commit_env_config, git2cpp_path, tmp_path, text_flag):
+def test_diff_text(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path, text_flag
+):
     """Test diff with -a/--text (treat all files as text)"""
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
-    binary_file = xtl_path / "binary.bin"
+    binary_file = tmp_path / "binary.bin"
     binary_file.write_bytes(b"\x00\x01\x02\x03")
 
     cmd_add = [git2cpp_path, "add", "binary.bin"]
-    subprocess.run(cmd_add, cwd=xtl_path, check=True)
+    subprocess.run(cmd_add, cwd=tmp_path, check=True)
 
     cmd_commit = [git2cpp_path, "commit", "-m", "add binary"]
-    subprocess.run(cmd_commit, cwd=xtl_path, check=True)
+    subprocess.run(cmd_commit, cwd=tmp_path, check=True)
 
     binary_file.write_bytes(b"\x00\x01\x02\x04")
 
     cmd_text = [git2cpp_path, "diff", text_flag]
-    p = subprocess.run(cmd_text, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd_text, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
     assert "binary.bin" in p.stdout
     assert "@@" in p.stdout
 
 
-def test_diff_ignore_space_at_eol(xtl_clone, git2cpp_path, tmp_path):
+def test_diff_ignore_space_at_eol(repo_init_with_commit, git2cpp_path, tmp_path):
     """Test diff with --ignore-space-at-eol"""
-    xtl_path = tmp_path / "xtl"
+    initial_file = tmp_path / "initial.txt"
+    assert (initial_file).exists()
 
-    readme = xtl_path / "README.md"
-    original = readme.read_text()
+    original = initial_file.read_text()
     # Add trailing spaces at end of line
-    readme.write_text(original.rstrip() + "  \n")
+    initial_file.write_text(original.rstrip() + "  \n")
 
     cmd = [git2cpp_path, "diff", "--ignore-space-at-eol"]
-    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
     assert p.stdout == ""
 
 
 @pytest.mark.parametrize("space_change_flag", ["-b", "--ignore-space-change"])
 def test_diff_ignore_space_change(
-    xtl_clone, commit_env_config, git2cpp_path, tmp_path, space_change_flag
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path, space_change_flag
 ):
     """Test diff with -b/--ignore-space-change"""
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
-    test_file = xtl_path / "test.txt"
+    test_file = tmp_path / "test.txt"
     test_file.write_text("Hello  world\n")
 
     cmd_add = [git2cpp_path, "add", "test.txt"]
-    subprocess.run(cmd_add, cwd=xtl_path, check=True)
+    subprocess.run(cmd_add, cwd=tmp_path, check=True)
 
     cmd_commit = [git2cpp_path, "commit", "-m", "test"]
-    subprocess.run(cmd_commit, cwd=xtl_path, check=True)
+    subprocess.run(cmd_commit, cwd=tmp_path, check=True)
 
     # Change spacing
     test_file.write_text("Hello    world\n")
 
     cmd_diff = [git2cpp_path, "diff", space_change_flag]
-    p = subprocess.run(cmd_diff, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd_diff, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
     assert p.stdout == ""
 
 
 @pytest.mark.parametrize("ignore_space_flag", ["-w", "--ignore-all-space"])
 def test_diff_ignore_all_space(
-    xtl_clone, commit_env_config, git2cpp_path, tmp_path, ignore_space_flag
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path, ignore_space_flag
 ):
     """Test diff with -w/--ignore-all-space"""
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
-    test_file = xtl_path / "test.txt"
+    test_file = tmp_path / "test.txt"
     test_file.write_text("Hello world\n")
 
     cmd_add = [git2cpp_path, "add", "test.txt"]
-    subprocess.run(cmd_add, cwd=xtl_path, check=True)
+    subprocess.run(cmd_add, cwd=tmp_path, check=True)
 
     cmd_commit = [git2cpp_path, "commit", "-m", "test"]
-    subprocess.run(cmd_commit, cwd=xtl_path, check=True)
+    subprocess.run(cmd_commit, cwd=tmp_path, check=True)
 
     test_file.write_text("Helloworld")
 
     cmd_diff = [git2cpp_path, "diff", ignore_space_flag]
-    p = subprocess.run(cmd_diff, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd_diff, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
     assert p.stdout == ""
 
@@ -286,7 +292,7 @@ def test_diff_ignore_all_space(
     [("-U0", 0), ("-U1", 1), ("-U5", 5), ("--unified=3", 3)],
 )
 def test_diff_unified_context(
-    xtl_clone,
+    repo_init_with_commit,
     commit_env_config,
     git2cpp_path,
     tmp_path,
@@ -294,19 +300,19 @@ def test_diff_unified_context(
     context_lines,
 ):
     """Test diff with -U/--unified for context lines"""
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
-    test_file = xtl_path / "test.txt"
+    test_file = tmp_path / "test.txt"
     # Create a file with enough lines to see context differences
     test_file.write_text(
         "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7\nLine 8\nLine 9\nLine 10\n"
     )
 
     cmd_add = [git2cpp_path, "add", "test.txt"]
-    subprocess.run(cmd_add, cwd=xtl_path, check=True)
+    subprocess.run(cmd_add, cwd=tmp_path, check=True)
 
     cmd_commit = [git2cpp_path, "commit", "-m", "test"]
-    subprocess.run(cmd_commit, cwd=xtl_path, check=True)
+    subprocess.run(cmd_commit, cwd=tmp_path, check=True)
 
     # Modify line 5 (middle of the file)
     test_file.write_text(
@@ -315,7 +321,7 @@ def test_diff_unified_context(
 
     # Run diff with the parameterized flag
     cmd = [git2cpp_path, "diff", unified_context_flag]
-    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
     assert "test.txt" in p.stdout
     assert "MODIFIED LINE 5" in p.stdout
@@ -365,19 +371,21 @@ def test_diff_unified_context(
         assert "Line 8" not in p.stdout or p.stdout.count("Line 8") == 0
 
 
-def test_diff_inter_hunk_context(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_diff_inter_hunk_context(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test diff with --inter-hunk-context"""
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
-    test_file = xtl_path / "test.txt"
+    test_file = tmp_path / "test.txt"
     lines = [f"Line {i}\n" for i in range(1, 31)]
     test_file.write_text("".join(lines))
 
     cmd_add = [git2cpp_path, "add", "test.txt"]
-    subprocess.run(cmd_add, cwd=xtl_path, check=True)
+    subprocess.run(cmd_add, cwd=tmp_path, check=True)
 
     cmd_commit = [git2cpp_path, "commit", "-m", "test"]
-    subprocess.run(cmd_commit, cwd=xtl_path, check=True)
+    subprocess.run(cmd_commit, cwd=tmp_path, check=True)
 
     # Modify two separate sections
     lines[4] = "Modified Line 5\n"
@@ -386,7 +394,7 @@ def test_diff_inter_hunk_context(xtl_clone, commit_env_config, git2cpp_path, tmp
 
     # Test with small inter-hunk-context (should keep hunks separate)
     cmd_small = [git2cpp_path, "diff", "--inter-hunk-context=1"]
-    p_small = subprocess.run(cmd_small, capture_output=True, cwd=xtl_path, text=True)
+    p_small = subprocess.run(cmd_small, capture_output=True, cwd=tmp_path, text=True)
     assert p_small.returncode == 0
     assert "Modified Line 5" in p_small.stdout
     assert "Modified Line 20" in p_small.stdout
@@ -403,7 +411,7 @@ def test_diff_inter_hunk_context(xtl_clone, commit_env_config, git2cpp_path, tmp
 
     # Test with large inter-hunk-context (should merge hunks into one)
     cmd_large = [git2cpp_path, "diff", "--inter-hunk-context=15"]
-    p_large = subprocess.run(cmd_large, capture_output=True, cwd=xtl_path, text=True)
+    p_large = subprocess.run(cmd_large, capture_output=True, cwd=tmp_path, text=True)
     assert p_large.returncode == 0
     assert "Modified Line 5" in p_large.stdout
     assert "Modified Line 20" in p_large.stdout
@@ -428,18 +436,18 @@ def test_diff_inter_hunk_context(xtl_clone, commit_env_config, git2cpp_path, tmp
     )
 
 
-def test_diff_abbrev(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_diff_abbrev(repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path):
     """Test diff with --abbrev for object name abbreviation"""
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
-    test_file = xtl_path / "test.txt"
+    test_file = tmp_path / "test.txt"
     test_file.write_text("Original content\n")
 
     cmd_add = [git2cpp_path, "add", "test.txt"]
-    subprocess.run(cmd_add, cwd=xtl_path, check=True)
+    subprocess.run(cmd_add, cwd=tmp_path, check=True)
 
     cmd_commit = [git2cpp_path, "commit", "-m", "initial commit"]
-    subprocess.run(cmd_commit, cwd=xtl_path, check=True)
+    subprocess.run(cmd_commit, cwd=tmp_path, check=True)
 
     # Modify the file
     test_file.write_text("Modified content\n")
@@ -447,20 +455,20 @@ def test_diff_abbrev(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
     # Test default --abbrev
     cmd_default = [git2cpp_path, "diff", "--abbrev"]
     p_default = subprocess.run(
-        cmd_default, capture_output=True, cwd=xtl_path, text=True
+        cmd_default, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_default.returncode == 0
     assert "test.txt" in p_default.stdout
 
     # Test --abbrev=7 (short hash)
     cmd_7 = [git2cpp_path, "diff", "--abbrev=7"]
-    p_7 = subprocess.run(cmd_7, capture_output=True, cwd=xtl_path, text=True)
+    p_7 = subprocess.run(cmd_7, capture_output=True, cwd=tmp_path, text=True)
     assert p_7.returncode == 0
     assert "test.txt" in p_7.stdout
 
     # Test --abbrev=12 (longer hash)
     cmd_12 = [git2cpp_path, "diff", "--abbrev=12"]
-    p_12 = subprocess.run(cmd_12, capture_output=True, cwd=xtl_path, text=True)
+    p_12 = subprocess.run(cmd_12, capture_output=True, cwd=tmp_path, text=True)
     assert p_12.returncode == 0
     assert "test.txt" in p_12.stdout
 
@@ -480,41 +488,43 @@ def test_diff_abbrev(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
 
 
 # Note: only checking if the output is a diff
-def test_diff_patience(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_diff_patience(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test diff with --patience algorithm"""
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
-    test_file = xtl_path / "test.txt"
+    test_file = tmp_path / "test.txt"
     test_file.write_text("Line 1\nLine 2\nLine 3\n")
 
     cmd_add = [git2cpp_path, "add", "test.txt"]
-    subprocess.run(cmd_add, cwd=xtl_path, check=True)
+    subprocess.run(cmd_add, cwd=tmp_path, check=True)
 
     cmd_commit = [git2cpp_path, "commit", "-m", "test"]
-    subprocess.run(cmd_commit, cwd=xtl_path, check=True)
+    subprocess.run(cmd_commit, cwd=tmp_path, check=True)
 
     test_file.write_text("Line 1\nNew Line\nLine 2\nLine 3\n")
 
     cmd = [git2cpp_path, "diff"]
-    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
     assert "test.txt" in p.stdout
     assert "+New Line" in p.stdout
 
 
 # Note: only checking if the output is a diff
-def test_diff_minimal(xtl_clone, git2cpp_path, tmp_path):
+def test_diff_minimal(repo_init_with_commit, git2cpp_path, tmp_path):
     """Test diff with --minimal (spend extra time to find smallest diff)"""
-    xtl_path = tmp_path / "xtl"
+    initial_file = tmp_path / "initial.txt"
+    assert (initial_file).exists()
 
-    readme = xtl_path / "README.md"
-    original = readme.read_text()
-    readme.write_text(original + "\nExtra line\n")
+    original = initial_file.read_text()
+    initial_file.write_text(original + "\nExtra line\n")
 
     cmd = [git2cpp_path, "diff", "--minimal"]
-    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
-    assert "README.md" in p.stdout
+    assert "initial.txt" in p.stdout
     assert "+Extra line" in p.stdout
 
 

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -4,25 +4,26 @@ import pytest
 
 
 @pytest.mark.parametrize("format_flag", ["", "--format=full", "--format=fuller"])
-def test_log(xtl_clone, commit_env_config, git2cpp_path, tmp_path, format_flag):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_log(commit_env_config, git2cpp_path, tmp_path, format_flag):
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
-    p = xtl_path / "mook_file.txt"
+    p = tmp_path / "mook_file.txt"
     p.write_text("")
 
     cmd_add = [git2cpp_path, "add", "mook_file.txt"]
-    p_add = subprocess.run(cmd_add, cwd=xtl_path, text=True)
+    p_add = subprocess.run(cmd_add, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     cmd_commit = [git2cpp_path, "commit", "-m", "test commit"]
-    p_commit = subprocess.run(cmd_commit, cwd=xtl_path, text=True)
+    p_commit = subprocess.run(cmd_commit, cwd=tmp_path, text=True)
     assert p_commit.returncode == 0
 
     cmd_log = [git2cpp_path, "log"]
     if format_flag != "":
         cmd_log.append(format_flag)
-    p_log = subprocess.run(cmd_log, capture_output=True, cwd=xtl_path, text=True)
+    p_log = subprocess.run(cmd_log, capture_output=True, cwd=tmp_path, text=True)
     assert p_log.returncode == 0
     assert "Jane Doe" in p_log.stdout
     assert "test commit" in p_log.stdout
@@ -46,16 +47,37 @@ def test_log_nogit(commit_env_config, git2cpp_path, tmp_path):
 
 @pytest.mark.parametrize("max_count_flag", ["", "-n", "--max-count"])
 def test_max_count(
-    xtl_clone, commit_env_config, git2cpp_path, tmp_path, max_count_flag
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path, max_count_flag
 ):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
+
+    p2 = tmp_path / "second.txt"
+    p2.write_text("second file")
+
+    cmd_add2 = [git2cpp_path, "add", "second.txt"]
+    subprocess.run(cmd_add2, capture_output=True, cwd=tmp_path, text=True, check=True)
+
+    cmd_commit2 = [git2cpp_path, "commit", "-m", "Second commit"]
+    subprocess.run(
+        cmd_commit2, capture_output=True, cwd=tmp_path, text=True, check=True
+    )
+
+    p3 = tmp_path / "third.txt"
+    p3.write_text("third file")
+
+    cmd_add3 = [git2cpp_path, "add", "third.txt"]
+    subprocess.run(cmd_add3, capture_output=True, cwd=tmp_path, text=True, check=True)
+
+    cmd_commit3 = [git2cpp_path, "commit", "-m", "Third commit"]
+    subprocess.run(
+        cmd_commit3, capture_output=True, cwd=tmp_path, text=True, check=True
+    )
 
     cmd_log = [git2cpp_path, "log"]
     if max_count_flag != "":
         cmd_log.append(max_count_flag)
         cmd_log.append("2")
-    p_log = subprocess.run(cmd_log, capture_output=True, cwd=xtl_path, text=True)
+    p_log = subprocess.run(cmd_log, capture_output=True, cwd=tmp_path, text=True)
     assert p_log.returncode == 0
 
     if max_count_flag == "":
@@ -64,23 +86,24 @@ def test_max_count(
         assert p_log.stdout.count("Author") == 2
 
 
-def test_log_with_head_reference(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_log_with_head_reference(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test that HEAD reference is shown on the latest commit."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     # Create a new commit
-    p = xtl_path / "test_file.txt"
+    p = tmp_path / "test_file.txt"
     p.write_text("test content")
 
-    subprocess.run([git2cpp_path, "add", "test_file.txt"], cwd=xtl_path, check=True)
+    subprocess.run([git2cpp_path, "add", "test_file.txt"], cwd=tmp_path, check=True)
     subprocess.run(
-        [git2cpp_path, "commit", "-m", "test commit"], cwd=xtl_path, check=True
+        [git2cpp_path, "commit", "-m", "test commit"], cwd=tmp_path, check=True
     )
 
     # Run log with max count 1 to get only the latest commit
     p_log = subprocess.run(
-        [git2cpp_path, "log", "-n", "1"], capture_output=True, cwd=xtl_path, text=True
+        [git2cpp_path, "log", "-n", "1"], capture_output=True, cwd=tmp_path, text=True
     )
     assert p_log.returncode == 0
 
@@ -89,26 +112,27 @@ def test_log_with_head_reference(xtl_clone, commit_env_config, git2cpp_path, tmp
     assert "master" in p_log.stdout or "main" in p_log.stdout
 
 
-def test_log_with_tag(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_log_with_tag(commit_env_config, git2cpp_path, tmp_path):
     """Test that tags are shown in log output."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create a commit and tag it
-    p = xtl_path / "tagged_file.txt"
+    p = tmp_path / "tagged_file.txt"
     p.write_text("tagged content")
 
-    subprocess.run([git2cpp_path, "add", "tagged_file.txt"], cwd=xtl_path, check=True)
+    subprocess.run([git2cpp_path, "add", "tagged_file.txt"], cwd=tmp_path, check=True)
     subprocess.run(
-        [git2cpp_path, "commit", "-m", "tagged commit"], cwd=xtl_path, check=True
+        [git2cpp_path, "commit", "-m", "tagged commit"], cwd=tmp_path, check=True
     )
 
     # Create a tag (using git command since git2cpp might not have tag creation yet)
-    subprocess.run(["git", "tag", "v1.0.0"], cwd=xtl_path, check=True)
+    subprocess.run([git2cpp_path, "tag", "v1.0.0"], cwd=tmp_path, check=True)
 
     # Run log
     p_log = subprocess.run(
-        [git2cpp_path, "log", "-n", "1"], capture_output=True, cwd=xtl_path, text=True
+        [git2cpp_path, "log", "-n", "1"], capture_output=True, cwd=tmp_path, text=True
     )
     assert p_log.returncode == 0
 
@@ -116,30 +140,31 @@ def test_log_with_tag(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
     assert "tag: v1.0.0" in p_log.stdout
 
 
-def test_log_with_multiple_tags(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_log_with_multiple_tags(commit_env_config, git2cpp_path, tmp_path):
     """Test that multiple tags on the same commit are all shown."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create a commit
-    p = xtl_path / "multi_tag_file.txt"
+    p = tmp_path / "multi_tag_file.txt"
     p.write_text("content")
 
     subprocess.run(
-        [git2cpp_path, "add", "multi_tag_file.txt"], cwd=xtl_path, check=True
+        [git2cpp_path, "add", "multi_tag_file.txt"], cwd=tmp_path, check=True
     )
     subprocess.run(
-        [git2cpp_path, "commit", "-m", "multi tag commit"], cwd=xtl_path, check=True
+        [git2cpp_path, "commit", "-m", "multi tag commit"], cwd=tmp_path, check=True
     )
 
     # Create multiple tags
-    subprocess.run(["git", "tag", "v1.0.0"], cwd=xtl_path, check=True)
-    subprocess.run(["git", "tag", "stable"], cwd=xtl_path, check=True)
-    subprocess.run(["git", "tag", "latest"], cwd=xtl_path, check=True)
+    subprocess.run([git2cpp_path, "tag", "v1.0.0"], cwd=tmp_path, check=True)
+    subprocess.run([git2cpp_path, "tag", "stable"], cwd=tmp_path, check=True)
+    subprocess.run([git2cpp_path, "tag", "latest"], cwd=tmp_path, check=True)
 
     # Run log
     p_log = subprocess.run(
-        [git2cpp_path, "log", "-n", "1"], capture_output=True, cwd=xtl_path, text=True
+        [git2cpp_path, "log", "-n", "1"], capture_output=True, cwd=tmp_path, text=True
     )
     assert p_log.returncode == 0
 
@@ -149,30 +174,33 @@ def test_log_with_multiple_tags(xtl_clone, commit_env_config, git2cpp_path, tmp_
     assert "tag: latest" in p_log.stdout
 
 
-def test_log_with_annotated_tag(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_log_with_annotated_tag(commit_env_config, git2cpp_path, tmp_path):
     """Test that annotated tags are shown in log output."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create a commit
-    p = xtl_path / "annotated_tag_file.txt"
+    p = tmp_path / "annotated_tag_file.txt"
     p.write_text("content")
 
     subprocess.run(
-        [git2cpp_path, "add", "annotated_tag_file.txt"], cwd=xtl_path, check=True
+        [git2cpp_path, "add", "annotated_tag_file.txt"], cwd=tmp_path, check=True
     )
     subprocess.run(
-        [git2cpp_path, "commit", "-m", "annotated tag commit"], cwd=xtl_path, check=True
+        [git2cpp_path, "commit", "-m", "annotated tag commit"], cwd=tmp_path, check=True
     )
 
     # Create an annotated tag
     subprocess.run(
-        ["git", "tag", "-a", "v2.0.0", "-m", "Version 2.0.0"], cwd=xtl_path, check=True
+        ["git", "tag", "-a", "v2.0.0", "-m", "Version 2.0.0"],
+        cwd=tmp_path,
+        check=True,
     )
 
     # Run log
     p_log = subprocess.run(
-        [git2cpp_path, "log", "-n", "1"], capture_output=True, cwd=xtl_path, text=True
+        [git2cpp_path, "log", "-n", "1"], capture_output=True, cwd=tmp_path, text=True
     )
     assert p_log.returncode == 0
 
@@ -180,26 +208,27 @@ def test_log_with_annotated_tag(xtl_clone, commit_env_config, git2cpp_path, tmp_
     assert "tag: v2.0.0" in p_log.stdout
 
 
-def test_log_with_branch(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_log_with_branch(commit_env_config, git2cpp_path, tmp_path):
     """Test that branches are shown in log output."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create a commit
-    p = xtl_path / "branch_file.txt"
+    p = tmp_path / "branch_file.txt"
     p.write_text("content")
 
-    subprocess.run([git2cpp_path, "add", "branch_file.txt"], cwd=xtl_path, check=True)
+    subprocess.run([git2cpp_path, "add", "branch_file.txt"], cwd=tmp_path, check=True)
     subprocess.run(
-        [git2cpp_path, "commit", "-m", "branch commit"], cwd=xtl_path, check=True
+        [git2cpp_path, "commit", "-m", "branch commit"], cwd=tmp_path, check=True
     )
 
     # Create a new branch pointing to HEAD
-    subprocess.run(["git", "branch", "feature-branch"], cwd=xtl_path, check=True)
+    subprocess.run([git2cpp_path, "branch", "feature-branch"], cwd=tmp_path, check=True)
 
     # Run log
     p_log = subprocess.run(
-        [git2cpp_path, "log", "-n", "1"], capture_output=True, cwd=xtl_path, text=True
+        [git2cpp_path, "log", "-n", "1"], capture_output=True, cwd=tmp_path, text=True
     )
     assert p_log.returncode == 0
 
@@ -223,25 +252,24 @@ def test_log_with_remote_branches(xtl_clone, commit_env_config, git2cpp_path, tm
     assert "origin/master" in p_log.stdout
 
 
-def test_log_commit_without_references(
-    xtl_clone, commit_env_config, git2cpp_path, tmp_path
-):
+def test_log_commit_without_references(commit_env_config, git2cpp_path, tmp_path):
     """Test that commits without any references don't show empty parentheses."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create two commits - the second one will have refs, the first won't
     for i in range(2):
-        p = xtl_path / f"file_{i}.txt"
+        p = tmp_path / f"file_{i}.txt"
         p.write_text(f"content {i}")
-        subprocess.run([git2cpp_path, "add", f"file_{i}.txt"], cwd=xtl_path, check=True)
+        subprocess.run([git2cpp_path, "add", f"file_{i}.txt"], cwd=tmp_path, check=True)
         subprocess.run(
-            [git2cpp_path, "commit", "-m", f"commit {i}"], cwd=xtl_path, check=True
+            [git2cpp_path, "commit", "-m", f"commit {i}"], cwd=tmp_path, check=True
         )
 
     # Run log with 2 commits
     p_log = subprocess.run(
-        [git2cpp_path, "log", "-n", "2"], capture_output=True, cwd=xtl_path, text=True
+        [git2cpp_path, "log", "-n", "2"], capture_output=True, cwd=tmp_path, text=True
     )
     assert p_log.returncode == 0
 

--- a/test/test_merge.py
+++ b/test/test_merge.py
@@ -5,159 +5,184 @@ import pytest
 
 # TODO: Have a different "person" for the commit and for the merge
 # TODO: Test "unborn" case, but how ?
-def test_merge_fast_forward(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_merge_fast_forward(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
+    assert (tmp_path / "initial.txt").exists()
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     checkout_cmd = [git2cpp_path, "checkout", "-b", "foregone"]
     p_checkout = subprocess.run(
-        checkout_cmd, capture_output=True, cwd=xtl_path, text=True
+        checkout_cmd, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_checkout.returncode == 0
 
-    file_path = xtl_path / "mook_file.txt"
+    file_path = tmp_path / "mook_file.txt"
     file_path.write_text("blablabla")
 
     add_cmd = [git2cpp_path, "add", "mook_file.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     commit_cmd = [git2cpp_path, "commit", "-m", "test commit"]
-    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_commit.returncode == 0
 
-    checkout_cmd_2 = [git2cpp_path, "checkout", "master"]
+    checkout_cmd_2 = [git2cpp_path, "checkout", default_branch]
     p_checkout_2 = subprocess.run(
-        checkout_cmd_2, capture_output=True, cwd=xtl_path, text=True
+        checkout_cmd_2, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_checkout_2.returncode == 0
 
     merge_cmd = [git2cpp_path, "merge", "foregone"]
-    p_merge = subprocess.run(merge_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_merge = subprocess.run(merge_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_merge.returncode == 0
     assert "Fast-forward" in p_merge.stdout
 
     log_cmd = [git2cpp_path, "log", "--format=full", "--max-count", "1"]
-    p_log = subprocess.run(log_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_log = subprocess.run(log_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_log.returncode == 0
     assert "Author:	Jane Doe" in p_log.stdout
     # assert "Commit:	John Doe" in p_log.stdout
-    assert (xtl_path / "mook_file.txt").exists()
+    assert (tmp_path / "mook_file.txt").exists()
 
     merge_cmd_2 = [git2cpp_path, "merge", "foregone"]
     p_merge_2 = subprocess.run(
-        merge_cmd_2, capture_output=True, cwd=xtl_path, text=True
+        merge_cmd_2, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_merge_2.returncode == 0
     assert p_merge_2.stdout == "Already up-to-date\n"
 
 
-def test_merge_commit(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_merge_commit(repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path):
+    assert (tmp_path / "initial.txt").exists()
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     checkout_cmd = [git2cpp_path, "checkout", "-b", "foregone"]
     p_checkout = subprocess.run(
-        checkout_cmd, capture_output=True, cwd=xtl_path, text=True
+        checkout_cmd, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_checkout.returncode == 0
 
-    file_path = xtl_path / "mook_file.txt"
+    file_path = tmp_path / "mook_file.txt"
     file_path.write_text("blablabla")
 
     add_cmd = [git2cpp_path, "add", "mook_file.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     commit_cmd = [git2cpp_path, "commit", "-m", "test commit foregone"]
-    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_commit.returncode == 0
 
-    checkout_cmd_2 = [git2cpp_path, "checkout", "master"]
+    checkout_cmd_2 = [git2cpp_path, "checkout", default_branch]
     p_checkout_2 = subprocess.run(
-        checkout_cmd_2, capture_output=True, cwd=xtl_path, text=True
+        checkout_cmd_2, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_checkout_2.returncode == 0
 
-    file_path_2 = xtl_path / "mook_file_2.txt"
+    file_path_2 = tmp_path / "mook_file_2.txt"
     file_path_2.write_text("BLABLABLA")
 
     add_cmd_2 = [git2cpp_path, "add", "mook_file_2.txt"]
-    p_add_2 = subprocess.run(add_cmd_2, capture_output=True, cwd=xtl_path, text=True)
+    p_add_2 = subprocess.run(add_cmd_2, capture_output=True, cwd=tmp_path, text=True)
     assert p_add_2.returncode == 0
 
     commit_cmd_2 = [git2cpp_path, "commit", "-m", "test commit master"]
     p_commit_2 = subprocess.run(
-        commit_cmd_2, capture_output=True, cwd=xtl_path, text=True
+        commit_cmd_2, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_commit_2.returncode == 0
 
     merge_cmd = [git2cpp_path, "merge", "foregone"]
-    p_merge = subprocess.run(merge_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_merge = subprocess.run(merge_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_merge.returncode == 0
 
     log_cmd = [git2cpp_path, "log", "--format=full", "--max-count", "2"]
-    p_log = subprocess.run(log_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_log = subprocess.run(log_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_log.returncode == 0
     assert "Author:	Jane Doe" in p_log.stdout
     # assert "Commit:	John Doe" in p_log.stdout
     assert "Johan" not in p_log.stdout
-    assert (xtl_path / "mook_file.txt").exists()
-    assert (xtl_path / "mook_file_2.txt").exists()
+    assert (tmp_path / "mook_file.txt").exists()
+    assert (tmp_path / "mook_file_2.txt").exists()
 
     merge_cmd_2 = [git2cpp_path, "merge", "foregone"]
     p_merge_2 = subprocess.run(
-        merge_cmd_2, capture_output=True, cwd=xtl_path, text=True
+        merge_cmd_2, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_merge_2.returncode == 0
     assert p_merge_2.stdout == "Already up-to-date\n"
 
 
 @pytest.mark.parametrize("flag", ["--abort", "--quit", "--continue"])
-def test_merge_conflict(xtl_clone, commit_env_config, git2cpp_path, tmp_path, flag):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_merge_conflict(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path, flag
+):
+    assert (tmp_path / "initial.txt").exists()
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     checkout_cmd = [git2cpp_path, "checkout", "-b", "foregone"]
     p_checkout = subprocess.run(
-        checkout_cmd, capture_output=True, cwd=xtl_path, text=True
+        checkout_cmd, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_checkout.returncode == 0
 
-    file_path = xtl_path / "mook_file.txt"
+    file_path = tmp_path / "mook_file.txt"
     file_path.write_text("blablabla")
 
-    file_path_2 = xtl_path / "mook_file_2.txt"
+    file_path_2 = tmp_path / "mook_file_2.txt"
     file_path_2.write_text("Second file")
 
     add_cmd = [git2cpp_path, "add", "--all"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     commit_cmd = [git2cpp_path, "commit", "-m", "test commit foregone"]
-    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_commit.returncode == 0
 
-    checkout_cmd_2 = [git2cpp_path, "checkout", "master"]
+    checkout_cmd_2 = [git2cpp_path, "checkout", default_branch]
     p_checkout_2 = subprocess.run(
-        checkout_cmd_2, capture_output=True, cwd=xtl_path, text=True
+        checkout_cmd_2, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_checkout_2.returncode == 0
 
     file_path.write_text("BLABLABLA")
 
     add_cmd_2 = [git2cpp_path, "add", "mook_file.txt"]
-    p_add_2 = subprocess.run(add_cmd_2, capture_output=True, cwd=xtl_path, text=True)
+    p_add_2 = subprocess.run(add_cmd_2, capture_output=True, cwd=tmp_path, text=True)
     assert p_add_2.returncode == 0
 
     commit_cmd_2 = [git2cpp_path, "commit", "-m", "test commit master"]
     p_commit_2 = subprocess.run(
-        commit_cmd_2, capture_output=True, cwd=xtl_path, text=True
+        commit_cmd_2, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_commit_2.returncode == 0
 
     merge_cmd = [git2cpp_path, "merge", "foregone"]
-    p_merge = subprocess.run(merge_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_merge = subprocess.run(merge_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_merge.returncode == 0
     assert "conflict: " in p_merge.stdout
 
@@ -165,11 +190,11 @@ def test_merge_conflict(xtl_clone, commit_env_config, git2cpp_path, tmp_path, fl
     if flag == "--abort":
         for answer in {"y", ""}:
             p_abort = subprocess.run(
-                flag_cmd, input=answer, capture_output=True, cwd=xtl_path, text=True
+                flag_cmd, input=answer, capture_output=True, cwd=tmp_path, text=True
             )
             assert p_abort.returncode == 0
-            assert (xtl_path / "mook_file.txt").exists()
-            text = (xtl_path / "mook_file.txt").read_text()
+            assert (tmp_path / "mook_file.txt").exists()
+            text = (tmp_path / "mook_file.txt").read_text()
             if answer == "y":
                 assert "BLA" in text
                 assert "bla" not in text
@@ -198,33 +223,33 @@ def test_merge_conflict(xtl_clone, commit_env_config, git2cpp_path, tmp_path, fl
         # This checks the merge behaviour when a different branch name points to the same commit.
         branch_alias_cmd = [git2cpp_path, "branch", "foregone_alias"]
         p_branch_alias = subprocess.run(
-            branch_alias_cmd, capture_output=True, cwd=xtl_path, text=True
+            branch_alias_cmd, capture_output=True, cwd=tmp_path, text=True
         )
         assert p_branch_alias.returncode == 0
 
         file_path.write_text("blablabla")
 
         cmd_add = [git2cpp_path, "add", "mook_file.txt"]
-        p_add = subprocess.run(cmd_add, cwd=xtl_path, text=True)
+        p_add = subprocess.run(cmd_add, cwd=tmp_path, text=True)
         assert p_add.returncode == 0
 
         p_continue = subprocess.run(
-            flag_cmd, capture_output=True, cwd=xtl_path, text=True
+            flag_cmd, capture_output=True, cwd=tmp_path, text=True
         )
         assert p_continue.returncode == 0
 
         log_cmd = [git2cpp_path, "log", "--format=full", "--max-count", "2"]
-        p_log = subprocess.run(log_cmd, capture_output=True, cwd=xtl_path, text=True)
+        p_log = subprocess.run(log_cmd, capture_output=True, cwd=tmp_path, text=True)
         assert p_log.returncode == 0
         assert "Author:	Jane Doe" in p_log.stdout
         # assert "Commit:	John Doe" in p_log.stdout
         assert "Johan" not in p_log.stdout
-        assert (xtl_path / "mook_file.txt").exists()
-        assert (xtl_path / "mook_file_2.txt").exists()
+        assert (tmp_path / "mook_file.txt").exists()
+        assert (tmp_path / "mook_file_2.txt").exists()
 
         merge_cmd_2 = [git2cpp_path, "merge", "foregone"]
         p_merge_2 = subprocess.run(
-            merge_cmd_2, capture_output=True, cwd=xtl_path, text=True
+            merge_cmd_2, capture_output=True, cwd=tmp_path, text=True
         )
         assert p_merge_2.returncode == 0
         assert p_merge_2.stdout == "Already up-to-date\n"

--- a/test/test_mv.py
+++ b/test/test_mv.py
@@ -3,89 +3,94 @@ import subprocess
 import pytest
 
 
-def test_mv_basic(xtl_clone, git2cpp_path, tmp_path):
+def test_mv_basic(git2cpp_path, tmp_path):
     """Test basic mv operation to rename a file"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create a test file
-    test_file = xtl_path / "test_file.txt"
+    test_file = tmp_path / "test_file.txt"
     test_file.write_text("test content")
 
     # Add the file to git
     add_cmd = [git2cpp_path, "add", "test_file.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     # Move/rename the file
     mv_cmd = [git2cpp_path, "mv", "test_file.txt", "renamed_file.txt"]
-    p_mv = subprocess.run(mv_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_mv = subprocess.run(mv_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_mv.returncode == 0
 
     # Verify the file was moved
     assert not test_file.exists()
-    assert (xtl_path / "renamed_file.txt").exists()
+    assert (tmp_path / "renamed_file.txt").exists()
 
     # Check git status
     status_cmd = [git2cpp_path, "status", "--long"]
-    p_status = subprocess.run(status_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_status = subprocess.run(status_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_status.returncode == 0
-    # TODO: uncomment this when the status command is fixed.
-    #assert "renamed:" in p_status.stdout and "renamed_file.txt" in p_status.stdout
+    assert "new file:   renamed_file.txt" in p_status.stdout
 
 
-def test_mv_to_subdirectory(xtl_clone, git2cpp_path, tmp_path):
+def test_mv_to_subdirectory(git2cpp_path, tmp_path):
     """Test moving a file to a subdirectory"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create a test file
-    test_file = xtl_path / "move_me.txt"
+    test_file = tmp_path / "move_me.txt"
     test_file.write_text("content to move")
 
     # Add the file to git
     add_cmd = [git2cpp_path, "add", "move_me.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
+    # Create a subdirectory
+    test_dir = tmp_path / "test"
+    test_dir.mkdir()
+
     # Move the file to existing subdirectory
-    mv_cmd = [git2cpp_path, "mv", "move_me.txt", "include/move_me.txt"]
-    p_mv = subprocess.run(mv_cmd, capture_output=True, cwd=xtl_path, text=True)
+    mv_cmd = [git2cpp_path, "mv", "move_me.txt", "test/move_me.txt"]
+    p_mv = subprocess.run(mv_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_mv.returncode == 0
 
     # Verify the file was moved
     assert not test_file.exists()
-    assert (xtl_path / "include" / "move_me.txt").exists()
+    assert (test_dir / "move_me.txt").exists()
 
     # Check git status
     status_cmd = [git2cpp_path, "status", "--long"]
-    p_status = subprocess.run(status_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_status = subprocess.run(status_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_status.returncode == 0
-    # TODO: uncomment this when the status command is fixed.
-    #assert "renamed:" in p_status.stdout and "move_me.txt" in p_status.stdout
+    assert "new file:   test/move_me.txt" in p_status.stdout
 
 
-def test_mv_destination_exists_without_force(xtl_clone, git2cpp_path, tmp_path):
+def test_mv_destination_exists_without_force(git2cpp_path, tmp_path):
     """Test that mv fails when destination exists without --force flag"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create source file
-    source_file = xtl_path / "source.txt"
+    source_file = tmp_path / "source.txt"
     source_file.write_text("source content")
 
     # Create destination file
-    dest_file = xtl_path / "destination.txt"
+    dest_file = tmp_path / "destination.txt"
     dest_file.write_text("destination content")
 
     # Add both files to git
     add_cmd = [git2cpp_path, "add", "source.txt", "destination.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     # Try to move without force - should fail
     mv_cmd = [git2cpp_path, "mv", "source.txt", "destination.txt"]
-    p_mv = subprocess.run(mv_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_mv = subprocess.run(mv_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_mv.returncode != 0
     assert "destination already exists" in p_mv.stderr
 
@@ -95,27 +100,28 @@ def test_mv_destination_exists_without_force(xtl_clone, git2cpp_path, tmp_path):
 
 
 @pytest.mark.parametrize("force_flag", ["-f", "--force"])
-def test_mv_destination_exists_with_force(xtl_clone, git2cpp_path, tmp_path, force_flag):
+def test_mv_destination_exists_with_force(git2cpp_path, tmp_path, force_flag):
     """Test that mv succeeds when destination exists with --force flag"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create source file
-    source_file = xtl_path / "source.txt"
+    source_file = tmp_path / "source.txt"
     source_file.write_text("source content")
 
     # Create destination file
-    dest_file = xtl_path / "destination.txt"
+    dest_file = tmp_path / "destination.txt"
     dest_file.write_text("destination content")
 
     # Add both files to git
     add_cmd = [git2cpp_path, "add", "source.txt", "destination.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     # Move with force - should succeed
     mv_cmd = [git2cpp_path, "mv", force_flag, "source.txt", "destination.txt"]
-    p_mv = subprocess.run(mv_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_mv = subprocess.run(mv_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_mv.returncode == 0
 
     # Verify source file was moved
@@ -124,92 +130,97 @@ def test_mv_destination_exists_with_force(xtl_clone, git2cpp_path, tmp_path, for
     assert dest_file.read_text() == "source content"
 
 
-def test_mv_nonexistent_source(xtl_clone, git2cpp_path, tmp_path):
+def test_mv_nonexistent_source(git2cpp_path, tmp_path):
     """Test that mv fails when source file doesn't exist"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Try to move a file that doesn't exist
     mv_cmd = [git2cpp_path, "mv", "nonexistent.txt", "destination.txt"]
-    p_mv = subprocess.run(mv_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_mv = subprocess.run(mv_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_mv.returncode != 0
 
 
-def test_mv_multiple_files(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_mv_multiple_files(commit_env_config, git2cpp_path, tmp_path):
     """Test moving multiple files sequentially"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create test files
-    file1 = xtl_path / "file1.txt"
+    file1 = tmp_path / "file1.txt"
     file1.write_text("content 1")
-    file2 = xtl_path / "file2.txt"
+    file2 = tmp_path / "file2.txt"
     file2.write_text("content 2")
 
     # Add files to git
     add_cmd = [git2cpp_path, "add", "file1.txt", "file2.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     # Commit the files
     commit_cmd = [git2cpp_path, "commit", "-m", "Add test files"]
-    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_commit.returncode == 0
 
     # Move first file
     mv_cmd1 = [git2cpp_path, "mv", "file1.txt", "renamed1.txt"]
-    p_mv1 = subprocess.run(mv_cmd1, capture_output=True, cwd=xtl_path, text=True)
+    p_mv1 = subprocess.run(mv_cmd1, capture_output=True, cwd=tmp_path, text=True)
     assert p_mv1.returncode == 0
 
     # Move second file
     mv_cmd2 = [git2cpp_path, "mv", "file2.txt", "renamed2.txt"]
-    p_mv2 = subprocess.run(mv_cmd2, capture_output=True, cwd=xtl_path, text=True)
+    p_mv2 = subprocess.run(mv_cmd2, capture_output=True, cwd=tmp_path, text=True)
     assert p_mv2.returncode == 0
 
     # Verify both files were moved
     assert not file1.exists()
     assert not file2.exists()
-    assert (xtl_path / "renamed1.txt").exists()
-    assert (xtl_path / "renamed2.txt").exists()
+    assert (tmp_path / "renamed1.txt").exists()
+    assert (tmp_path / "renamed2.txt").exists()
 
 
-def test_mv_and_commit(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_mv_and_commit(commit_env_config, git2cpp_path, tmp_path):
     """Test moving a file and committing the change"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create a test file
-    test_file = xtl_path / "original.txt"
+    test_file = tmp_path / "original.txt"
     test_file.write_text("original content")
 
     # Add and commit the file
     add_cmd = [git2cpp_path, "add", "original.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     commit_cmd = [git2cpp_path, "commit", "-m", "Add original file"]
-    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_commit.returncode == 0
 
     # Move the file
     mv_cmd = [git2cpp_path, "mv", "original.txt", "moved.txt"]
-    p_mv = subprocess.run(mv_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_mv = subprocess.run(mv_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_mv.returncode == 0
 
     # Check status before commit
     status_cmd = [git2cpp_path, "status", "--long"]
-    p_status = subprocess.run(status_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_status = subprocess.run(status_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_status.returncode == 0
     assert "Changes to be committed" in p_status.stdout
 
     # Commit the move
     commit_cmd2 = [git2cpp_path, "commit", "-m", "Move file"]
-    p_commit2 = subprocess.run(commit_cmd2, capture_output=True, cwd=xtl_path, text=True)
+    p_commit2 = subprocess.run(
+        commit_cmd2, capture_output=True, cwd=tmp_path, text=True
+    )
     assert p_commit2.returncode == 0
 
     # Verify the file is in the new location
-    assert not (xtl_path / "original.txt").exists()
-    assert (xtl_path / "moved.txt").exists()
+    assert not (tmp_path / "original.txt").exists()
+    assert (tmp_path / "moved.txt").exists()
 
 
 def test_mv_nogit(git2cpp_path, tmp_path):
@@ -224,27 +235,28 @@ def test_mv_nogit(git2cpp_path, tmp_path):
     assert p_mv.returncode != 0
 
 
-def test_mv_preserve_content(xtl_clone, git2cpp_path, tmp_path):
+def test_mv_preserve_content(git2cpp_path, tmp_path):
     """Test that file content is preserved after mv"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create a test file with specific content
     test_content = "This is important content that should be preserved"
-    test_file = xtl_path / "important.txt"
+    test_file = tmp_path / "important.txt"
     test_file.write_text(test_content)
 
     # Add the file to git
     add_cmd = [git2cpp_path, "add", "important.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     # Move the file
     mv_cmd = [git2cpp_path, "mv", "important.txt", "preserved.txt"]
-    p_mv = subprocess.run(mv_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_mv = subprocess.run(mv_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_mv.returncode == 0
 
     # Verify content is preserved
-    moved_file = xtl_path / "preserved.txt"
+    moved_file = tmp_path / "preserved.txt"
     assert moved_file.exists()
     assert moved_file.read_text() == test_content

--- a/test/test_rebase.py
+++ b/test/test_rebase.py
@@ -3,159 +3,184 @@ import subprocess
 import pytest
 
 
-def test_rebase_basic(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rebase_basic(repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path):
     """Test basic rebase operation with fast-forward"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     # Create a feature branch
     checkout_cmd = [git2cpp_path, "checkout", "-b", "feature"]
     p_checkout = subprocess.run(
-        checkout_cmd, capture_output=True, cwd=xtl_path, text=True
+        checkout_cmd, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_checkout.returncode == 0
 
     # Create a commit on feature branch
-    file_path = xtl_path / "feature_file.txt"
+    file_path = tmp_path / "feature_file.txt"
     file_path.write_text("feature content")
 
     add_cmd = [git2cpp_path, "add", "feature_file.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     commit_cmd = [git2cpp_path, "commit", "-m", "feature commit"]
-    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_commit.returncode == 0
 
     # Go back to master and create another commit
-    checkout_master_cmd = [git2cpp_path, "checkout", "master"]
+    checkout_master_cmd = [git2cpp_path, "checkout", default_branch]
     p_checkout_master = subprocess.run(
-        checkout_master_cmd, capture_output=True, cwd=xtl_path, text=True
+        checkout_master_cmd, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_checkout_master.returncode == 0
 
-    file_path_2 = xtl_path / "master_file.txt"
+    file_path_2 = tmp_path / "master_file.txt"
     file_path_2.write_text("master content")
 
     add_cmd_2 = [git2cpp_path, "add", "master_file.txt"]
-    p_add_2 = subprocess.run(add_cmd_2, capture_output=True, cwd=xtl_path, text=True)
+    p_add_2 = subprocess.run(add_cmd_2, capture_output=True, cwd=tmp_path, text=True)
     assert p_add_2.returncode == 0
 
     commit_cmd_2 = [git2cpp_path, "commit", "-m", "master commit"]
     p_commit_2 = subprocess.run(
-        commit_cmd_2, capture_output=True, cwd=xtl_path, text=True
+        commit_cmd_2, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_commit_2.returncode == 0
 
     # Switch to feature and rebase onto master
     checkout_feature_cmd = [git2cpp_path, "checkout", "feature"]
     p_checkout_feature = subprocess.run(
-        checkout_feature_cmd, capture_output=True, cwd=xtl_path, text=True
+        checkout_feature_cmd, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_checkout_feature.returncode == 0
 
-    rebase_cmd = [git2cpp_path, "rebase", "master"]
-    p_rebase = subprocess.run(rebase_cmd, capture_output=True, cwd=xtl_path, text=True)
+    rebase_cmd = [git2cpp_path, "rebase", default_branch]
+    p_rebase = subprocess.run(rebase_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_rebase.returncode == 0
     assert "Successfully rebased" in p_rebase.stdout
     assert "Rebasing 1 commit(s)" in p_rebase.stdout
 
     # Verify both files exist
-    assert (xtl_path / "feature_file.txt").exists()
-    assert (xtl_path / "master_file.txt").exists()
+    assert (tmp_path / "feature_file.txt").exists()
+    assert (tmp_path / "master_file.txt").exists()
 
 
-def test_rebase_multiple_commits(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rebase_multiple_commits(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test rebase with multiple commits"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     # Create feature branch with multiple commits
     checkout_cmd = [git2cpp_path, "checkout", "-b", "feature"]
     p_checkout = subprocess.run(
-        checkout_cmd, capture_output=True, cwd=xtl_path, text=True
+        checkout_cmd, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_checkout.returncode == 0
 
     # First commit
-    file_1 = xtl_path / "file_1.txt"
+    file_1 = tmp_path / "file_1.txt"
     file_1.write_text("content 1")
     add_cmd_1 = [git2cpp_path, "add", "file_1.txt"]
-    subprocess.run(add_cmd_1, cwd=xtl_path, text=True)
+    subprocess.run(add_cmd_1, cwd=tmp_path, text=True)
     commit_cmd_1 = [git2cpp_path, "commit", "-m", "commit 1"]
-    subprocess.run(commit_cmd_1, cwd=xtl_path, text=True)
+    subprocess.run(commit_cmd_1, cwd=tmp_path, text=True)
 
     # Second commit
-    file_2 = xtl_path / "file_2.txt"
+    file_2 = tmp_path / "file_2.txt"
     file_2.write_text("content 2")
     add_cmd_2 = [git2cpp_path, "add", "file_2.txt"]
-    subprocess.run(add_cmd_2, cwd=xtl_path, text=True)
+    subprocess.run(add_cmd_2, cwd=tmp_path, text=True)
     commit_cmd_2 = [git2cpp_path, "commit", "-m", "commit 2"]
-    subprocess.run(commit_cmd_2, cwd=xtl_path, text=True)
+    subprocess.run(commit_cmd_2, cwd=tmp_path, text=True)
 
     # Third commit
-    file_3 = xtl_path / "file_3.txt"
+    file_3 = tmp_path / "file_3.txt"
     file_3.write_text("content 3")
     add_cmd_3 = [git2cpp_path, "add", "file_3.txt"]
-    subprocess.run(add_cmd_3, cwd=xtl_path, text=True)
+    subprocess.run(add_cmd_3, cwd=tmp_path, text=True)
     commit_cmd_3 = [git2cpp_path, "commit", "-m", "commit 3"]
-    subprocess.run(commit_cmd_3, cwd=xtl_path, text=True)
+    subprocess.run(commit_cmd_3, cwd=tmp_path, text=True)
 
     # Go to master and add a commit
-    checkout_master_cmd = [git2cpp_path, "checkout", "master"]
-    subprocess.run(checkout_master_cmd, cwd=xtl_path)
+    checkout_master_cmd = [git2cpp_path, "checkout", default_branch]
+    subprocess.run(checkout_master_cmd, cwd=tmp_path)
 
-    master_file = xtl_path / "master_file.txt"
+    master_file = tmp_path / "master_file.txt"
     master_file.write_text("master")
-    subprocess.run([git2cpp_path, "add", "master_file.txt"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "commit", "-m", "master commit"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "add", "master_file.txt"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "commit", "-m", "master commit"], cwd=tmp_path)
 
     # Rebase feature onto master
     checkout_feature_cmd = [git2cpp_path, "checkout", "feature"]
-    subprocess.run(checkout_feature_cmd, cwd=xtl_path)
+    subprocess.run(checkout_feature_cmd, cwd=tmp_path)
 
-    rebase_cmd = [git2cpp_path, "rebase", "master"]
-    p_rebase = subprocess.run(rebase_cmd, capture_output=True, cwd=xtl_path, text=True)
+    rebase_cmd = [git2cpp_path, "rebase", default_branch]
+    p_rebase = subprocess.run(rebase_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_rebase.returncode == 0
     assert "Rebasing 3 commit(s)" in p_rebase.stdout
     assert "Successfully rebased" in p_rebase.stdout
 
     # Verify all files exist
-    assert (xtl_path / "file_1.txt").exists()
-    assert (xtl_path / "file_2.txt").exists()
-    assert (xtl_path / "file_3.txt").exists()
-    assert (xtl_path / "master_file.txt").exists()
+    assert (tmp_path / "file_1.txt").exists()
+    assert (tmp_path / "file_2.txt").exists()
+    assert (tmp_path / "file_3.txt").exists()
+    assert (tmp_path / "master_file.txt").exists()
 
 
-def test_rebase_with_conflicts(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rebase_with_conflicts(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test rebase with conflicts"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     # Create feature branch
     checkout_cmd = [git2cpp_path, "checkout", "-b", "feature"]
-    subprocess.run(checkout_cmd, capture_output=True, cwd=xtl_path, text=True)
+    subprocess.run(checkout_cmd, capture_output=True, cwd=tmp_path, text=True)
 
     # Create conflicting file on feature
-    conflict_file = xtl_path / "conflict.txt"
+    conflict_file = tmp_path / "conflict.txt"
     conflict_file.write_text("feature content")
-    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "commit", "-m", "feature commit"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "commit", "-m", "feature commit"], cwd=tmp_path)
 
     # Go to master and create conflicting commit
-    checkout_master_cmd = [git2cpp_path, "checkout", "master"]
-    subprocess.run(checkout_master_cmd, cwd=xtl_path)
+    checkout_master_cmd = [git2cpp_path, "checkout", default_branch]
+    subprocess.run(checkout_master_cmd, cwd=tmp_path)
 
     conflict_file.write_text("master content")
-    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "commit", "-m", "master commit"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "commit", "-m", "master commit"], cwd=tmp_path)
 
     # Try to rebase feature onto master
     checkout_feature_cmd = [git2cpp_path, "checkout", "feature"]
-    subprocess.run(checkout_feature_cmd, cwd=xtl_path)
+    subprocess.run(checkout_feature_cmd, cwd=tmp_path)
 
-    rebase_cmd = [git2cpp_path, "rebase", "master"]
-    p_rebase = subprocess.run(rebase_cmd, capture_output=True, cwd=xtl_path, text=True)
+    rebase_cmd = [git2cpp_path, "rebase", default_branch]
+    p_rebase = subprocess.run(rebase_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_rebase.returncode == 0
     assert "Conflicts detected" in p_rebase.stdout
     assert "rebase --continue" in p_rebase.stdout
@@ -163,34 +188,41 @@ def test_rebase_with_conflicts(xtl_clone, commit_env_config, git2cpp_path, tmp_p
     assert "rebase --abort" in p_rebase.stdout
 
 
-def test_rebase_abort(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rebase_abort(repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path):
     """Test rebase abort after conflicts"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     # Create feature branch
     checkout_cmd = [git2cpp_path, "checkout", "-b", "feature"]
-    subprocess.run(checkout_cmd, cwd=xtl_path)
+    subprocess.run(checkout_cmd, cwd=tmp_path)
 
     # Create conflicting file on feature
-    conflict_file = xtl_path / "conflict.txt"
+    conflict_file = tmp_path / "conflict.txt"
     conflict_file.write_text("feature content")
-    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "commit", "-m", "feature commit"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "commit", "-m", "feature commit"], cwd=tmp_path)
 
     # Go to master and create conflicting commit
-    subprocess.run([git2cpp_path, "checkout", "master"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "checkout", default_branch], cwd=tmp_path)
     conflict_file.write_text("master content")
-    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "commit", "-m", "master commit"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "commit", "-m", "master commit"], cwd=tmp_path)
 
     # Rebase and get conflict
-    subprocess.run([git2cpp_path, "checkout", "feature"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "rebase", "master"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "checkout", "feature"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "rebase", default_branch], cwd=tmp_path)
 
     # Abort the rebase
     abort_cmd = [git2cpp_path, "rebase", "--abort"]
-    p_abort = subprocess.run(abort_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_abort = subprocess.run(abort_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_abort.returncode == 0
     assert "Rebase aborted" in p_abort.stdout
 
@@ -198,38 +230,47 @@ def test_rebase_abort(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
     assert conflict_file.read_text() == "feature content"
 
 
-def test_rebase_continue(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rebase_continue(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test rebase continue after resolving conflicts"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     # Create feature branch
-    subprocess.run([git2cpp_path, "checkout", "-b", "feature"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "checkout", "-b", "feature"], cwd=tmp_path)
 
     # Create conflicting file on feature
-    conflict_file = xtl_path / "conflict.txt"
+    conflict_file = tmp_path / "conflict.txt"
     conflict_file.write_text("feature content")
-    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "commit", "-m", "feature commit"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "commit", "-m", "feature commit"], cwd=tmp_path)
 
     # Go to master and create conflicting commit
-    subprocess.run([git2cpp_path, "checkout", "master"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "checkout", default_branch], cwd=tmp_path)
     conflict_file.write_text("master content")
-    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "commit", "-m", "master commit"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "commit", "-m", "master commit"], cwd=tmp_path)
 
     # Rebase and get conflict
-    subprocess.run([git2cpp_path, "checkout", "feature"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "rebase", "master"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "checkout", "feature"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "rebase", default_branch], cwd=tmp_path)
 
     # Resolve conflict
     conflict_file.write_text("resolved content")
-    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=tmp_path)
 
     # Continue rebase
     continue_cmd = [git2cpp_path, "rebase", "--continue"]
     p_continue = subprocess.run(
-        continue_cmd, capture_output=True, cwd=xtl_path, text=True
+        continue_cmd, capture_output=True, cwd=tmp_path, text=True
     )
     assert p_continue.returncode == 0
     assert "Successfully rebased" in p_continue.stdout
@@ -238,191 +279,249 @@ def test_rebase_continue(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
     assert conflict_file.read_text() == "resolved content"
 
 
-def test_rebase_skip(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rebase_skip(repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path):
     """Test rebase skip to skip current commit"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     # Create feature branch
-    subprocess.run([git2cpp_path, "checkout", "-b", "feature"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "checkout", "-b", "feature"], cwd=tmp_path)
 
     # Create conflicting file on feature
-    conflict_file = xtl_path / "conflict.txt"
+    conflict_file = tmp_path / "conflict.txt"
     conflict_file.write_text("feature content")
-    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "commit", "-m", "feature commit"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "commit", "-m", "feature commit"], cwd=tmp_path)
 
     # Go to master and create conflicting commit
-    subprocess.run([git2cpp_path, "checkout", "master"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "checkout", default_branch], cwd=tmp_path)
     conflict_file.write_text("master content")
-    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "commit", "-m", "master commit"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "commit", "-m", "master commit"], cwd=tmp_path)
 
     # Rebase and get conflict
-    subprocess.run([git2cpp_path, "checkout", "feature"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "rebase", "master"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "checkout", "feature"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "rebase", default_branch], cwd=tmp_path)
 
     # Skip the conflicting commit
     skip_cmd = [git2cpp_path, "rebase", "--skip"]
-    p_skip = subprocess.run(skip_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_skip = subprocess.run(skip_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_skip.returncode == 0
     assert "Skipping" in p_skip.stdout
 
 
-def test_rebase_quit(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rebase_quit(repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path):
     """Test rebase quit to cleanup state without resetting HEAD"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     # Create feature branch
-    subprocess.run([git2cpp_path, "checkout", "-b", "feature"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "checkout", "-b", "feature"], cwd=tmp_path)
 
     # Create conflicting file
-    conflict_file = xtl_path / "conflict.txt"
+    conflict_file = tmp_path / "conflict.txt"
     conflict_file.write_text("feature content")
-    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "commit", "-m", "feature commit"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "commit", "-m", "feature commit"], cwd=tmp_path)
 
     # Create conflict on master
-    subprocess.run([git2cpp_path, "checkout", "master"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "checkout", default_branch], cwd=tmp_path)
     conflict_file.write_text("master content")
-    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "commit", "-m", "master commit"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "commit", "-m", "master commit"], cwd=tmp_path)
 
     # Start rebase
-    subprocess.run([git2cpp_path, "checkout", "feature"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "rebase", "master"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "checkout", "feature"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "rebase", default_branch], cwd=tmp_path)
 
     # Quit rebase
     quit_cmd = [git2cpp_path, "rebase", "--quit"]
-    p_quit = subprocess.run(quit_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_quit = subprocess.run(quit_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_quit.returncode == 0
     assert "Rebase state cleaned up" in p_quit.stdout
     assert "HEAD not reset" in p_quit.stdout
 
 
-def test_rebase_onto(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rebase_onto(repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path):
     """Test rebase with --onto option"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     # Create first branch
-    subprocess.run([git2cpp_path, "checkout", "-b", "branch1"], cwd=xtl_path)
-    file1 = xtl_path / "file1.txt"
+    subprocess.run([git2cpp_path, "checkout", "-b", "branch1"], cwd=tmp_path)
+    file1 = tmp_path / "file1.txt"
     file1.write_text("branch1")
-    subprocess.run([git2cpp_path, "add", "file1.txt"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "commit", "-m", "branch1 commit"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "add", "file1.txt"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "commit", "-m", "branch1 commit"], cwd=tmp_path)
 
     # Create second branch from branch1
-    subprocess.run([git2cpp_path, "checkout", "-b", "branch2"], cwd=xtl_path)
-    file2 = xtl_path / "file2.txt"
+    subprocess.run([git2cpp_path, "checkout", "-b", "branch2"], cwd=tmp_path)
+    file2 = tmp_path / "file2.txt"
     file2.write_text("branch2")
-    subprocess.run([git2cpp_path, "add", "file2.txt"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "commit", "-m", "branch2 commit"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "add", "file2.txt"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "commit", "-m", "branch2 commit"], cwd=tmp_path)
 
     # Create target branch from master
-    subprocess.run([git2cpp_path, "checkout", "master"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "checkout", "-b", "target"], cwd=xtl_path)
-    target_file = xtl_path / "target.txt"
+    subprocess.run([git2cpp_path, "checkout", default_branch], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "checkout", "-b", "target"], cwd=tmp_path)
+    target_file = tmp_path / "target.txt"
     target_file.write_text("target")
-    subprocess.run([git2cpp_path, "add", "target.txt"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "commit", "-m", "target commit"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "add", "target.txt"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "commit", "-m", "target commit"], cwd=tmp_path)
 
     # Rebase branch2 onto target, upstream is branch1
     rebase_cmd = [git2cpp_path, "rebase", "branch1", "branch2", "--onto", "target"]
-    p_rebase = subprocess.run(rebase_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_rebase = subprocess.run(rebase_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_rebase.returncode == 0
 
     # Verify target file exists and branch2 file exists, but not branch1 file
-    assert not (xtl_path / "target.txt").exists()
-    assert (xtl_path / "file2.txt").exists()
+    assert not (tmp_path / "target.txt").exists()
+    assert (tmp_path / "file2.txt").exists()
 
 
-def test_rebase_no_upstream_error(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rebase_no_upstream_error(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test that rebase without upstream argument fails"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     rebase_cmd = [git2cpp_path, "rebase"]
-    p_rebase = subprocess.run(rebase_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_rebase = subprocess.run(rebase_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_rebase.returncode != 0
     assert "upstream is required for rebase" in p_rebase.stderr
 
 
-def test_rebase_invalid_upstream_error(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rebase_invalid_upstream_error(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test that rebase with invalid upstream fails"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     rebase_cmd = [git2cpp_path, "rebase", "nonexistent-branch"]
-    p_rebase = subprocess.run(rebase_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_rebase = subprocess.run(rebase_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_rebase.returncode != 0
-    assert "could not resolve upstream" in p_rebase.stderr or "could not resolve upstream" in p_rebase.stdout
+    assert (
+        "could not resolve upstream" in p_rebase.stderr
+        or "could not resolve upstream" in p_rebase.stdout
+    )
 
 
-def test_rebase_already_in_progress_error(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rebase_already_in_progress_error(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test that starting rebase when one is in progress fails"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     # Create feature branch with conflict
-    subprocess.run([git2cpp_path, "checkout", "-b", "feature"], cwd=xtl_path)
-    conflict_file = xtl_path / "conflict.txt"
+    subprocess.run([git2cpp_path, "checkout", "-b", "feature"], cwd=tmp_path)
+    conflict_file = tmp_path / "conflict.txt"
     conflict_file.write_text("feature")
-    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "commit", "-m", "feature"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "commit", "-m", "feature"], cwd=tmp_path)
 
     # Create conflict on master
-    subprocess.run([git2cpp_path, "checkout", "master"], cwd=xtl_path)
-    conflict_file.write_text("master")
-    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "commit", "-m", "master"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "checkout", default_branch], cwd=tmp_path)
+    conflict_file.write_text(default_branch)
+    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "commit", "-m", default_branch], cwd=tmp_path)
 
     # Start rebase with conflict
-    subprocess.run([git2cpp_path, "checkout", "feature"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "rebase", "master"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "checkout", "feature"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "rebase", default_branch], cwd=tmp_path)
 
     # Try to start another rebase
-    rebase_cmd = [git2cpp_path, "rebase", "master"]
-    p_rebase = subprocess.run(rebase_cmd, capture_output=True, cwd=xtl_path, text=True)
+    rebase_cmd = [git2cpp_path, "rebase", default_branch]
+    p_rebase = subprocess.run(rebase_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_rebase.returncode != 0
-    assert "rebase is already in progress" in p_rebase.stderr or "rebase is already in progress" in p_rebase.stdout
+    assert (
+        "rebase is already in progress" in p_rebase.stderr
+        or "rebase is already in progress" in p_rebase.stdout
+    )
 
 
-def test_rebase_continue_without_rebase_error(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rebase_continue_without_rebase_error(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test that --continue without rebase in progress fails"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     continue_cmd = [git2cpp_path, "rebase", "--continue"]
-    p_continue = subprocess.run(continue_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_continue = subprocess.run(
+        continue_cmd, capture_output=True, cwd=tmp_path, text=True
+    )
     assert p_continue.returncode != 0
-    assert "No rebase in progress" in p_continue.stderr or "No rebase in progress" in p_continue.stdout
+    assert (
+        "No rebase in progress" in p_continue.stderr
+        or "No rebase in progress" in p_continue.stdout
+    )
 
 
-def test_rebase_continue_with_unresolved_conflicts(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rebase_continue_with_unresolved_conflicts(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test that --continue with unresolved conflicts fails"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     # Create conflict scenario
-    subprocess.run([git2cpp_path, "checkout", "-b", "feature"], cwd=xtl_path)
-    conflict_file = xtl_path / "conflict.txt"
+    subprocess.run([git2cpp_path, "checkout", "-b", "feature"], cwd=tmp_path)
+    conflict_file = tmp_path / "conflict.txt"
     conflict_file.write_text("feature")
-    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "commit", "-m", "feature"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "commit", "-m", "feature"], cwd=tmp_path)
 
-    subprocess.run([git2cpp_path, "checkout", "master"], cwd=xtl_path)
-    conflict_file.write_text("master")
-    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "commit", "-m", "master"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "checkout", default_branch], cwd=tmp_path)
+    conflict_file.write_text(default_branch)
+    subprocess.run([git2cpp_path, "add", "conflict.txt"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "commit", "-m", default_branch], cwd=tmp_path)
 
     # Start rebase
-    subprocess.run([git2cpp_path, "checkout", "feature"], cwd=xtl_path)
-    subprocess.run([git2cpp_path, "rebase", "master"], cwd=xtl_path)
+    subprocess.run([git2cpp_path, "checkout", "feature"], cwd=tmp_path)
+    subprocess.run([git2cpp_path, "rebase", default_branch], cwd=tmp_path)
 
     # Try to continue without resolving
     continue_cmd = [git2cpp_path, "rebase", "--continue"]
-    p_continue = subprocess.run(continue_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_continue = subprocess.run(
+        continue_cmd, capture_output=True, cwd=tmp_path, text=True
+    )
     assert p_continue.returncode != 0
-    assert "resolve conflicts" in p_continue.stderr or "resolve conflicts" in p_continue.stdout
+    assert (
+        "resolve conflicts" in p_continue.stderr
+        or "resolve conflicts" in p_continue.stdout
+    )

--- a/test/test_reset.py
+++ b/test/test_reset.py
@@ -3,34 +3,33 @@ import subprocess
 import pytest
 
 
-def test_reset(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_reset(repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path):
+    assert (tmp_path / "initial.txt").exists()
 
-    p = xtl_path / "mook_file.txt"
+    p = tmp_path / "mook_file.txt"
     p.write_text("")
 
     cmd_add = [git2cpp_path, "add", "mook_file.txt"]
-    p_add = subprocess.run(cmd_add, cwd=xtl_path, text=True)
+    p_add = subprocess.run(cmd_add, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     cmd_commit = [git2cpp_path, "commit", "-m", "test commit"]
-    p_commit = subprocess.run(cmd_commit, cwd=xtl_path, text=True)
+    p_commit = subprocess.run(cmd_commit, cwd=tmp_path, text=True)
     assert p_commit.returncode == 0
 
     cmd_log = [git2cpp_path, "log"]
-    p_log = subprocess.run(cmd_log, capture_output=True, cwd=xtl_path, text=True)
+    p_log = subprocess.run(cmd_log, capture_output=True, cwd=tmp_path, text=True)
     assert p_log.returncode == 0
-    assert "Jane Doe" in p_log.stdout
+    assert "test commit" in p_log.stdout
 
     cmd_reset = [git2cpp_path, "reset", "--hard", "HEAD~1"]
-    p_reset = subprocess.run(cmd_reset, capture_output=True, cwd=xtl_path, text=True)
+    p_reset = subprocess.run(cmd_reset, capture_output=True, cwd=tmp_path, text=True)
     assert p_reset.returncode == 0
 
     cmd_log_2 = [git2cpp_path, "log"]
-    p_log = subprocess.run(cmd_log_2, capture_output=True, cwd=xtl_path, text=True)
-    assert p_log.returncode == 0
-    assert "Jane Doe" not in p_log.stdout
+    p_log2 = subprocess.run(cmd_log_2, capture_output=True, cwd=tmp_path, text=True)
+    assert p_log2.returncode == 0
+    assert "test commit" not in p_log2.stdout
 
 
 def test_reset_nogit(git2cpp_path, tmp_path):

--- a/test/test_revlist.py
+++ b/test/test_revlist.py
@@ -3,18 +3,23 @@ import subprocess
 import pytest
 
 
-def test_revlist(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_revlist(repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path):
+    assert (tmp_path / "initial.txt").exists()
 
-    cmd = [
-        git2cpp_path,
-        "rev-list",
-        "35955995424eb9699bb604b988b5270253b1fccc",
-        "--max-count",
-        "2",
-    ]
-    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True)
+    p = tmp_path / "initial.txt"
+    p.write_text("commit2")
+    subprocess.run([git2cpp_path, "add", "initial.txt"], cwd=tmp_path, check=True)
+    subprocess.run([git2cpp_path, "commit", "-m", "commit 2"], cwd=tmp_path, check=True)
+
+    p.write_text("commit3")
+    subprocess.run([git2cpp_path, "add", "initial.txt"], cwd=tmp_path, check=True)
+    subprocess.run([git2cpp_path, "commit", "-m", "commit 3"], cwd=tmp_path, check=True)
+
+    cmd = [git2cpp_path, "rev-list", "HEAD", "--max-count", "2"]
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
-    assert "da1754dd6" in p.stdout
-    assert "2da8e13ef" not in p.stdout
+
+    lines = [l for l in p.stdout.splitlines() if l.strip()]
+    assert len(lines) == 2
+    assert all(len(oid) == 40 for oid in lines)
+    assert lines[0] != lines[1]

--- a/test/test_rm.py
+++ b/test/test_rm.py
@@ -1,29 +1,31 @@
+import pathlib
 import subprocess
 
 import pytest
 
 
-def test_rm_basic_file(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rm_basic_file(commit_env_config, git2cpp_path, tmp_path):
     """Test basic rm operation to remove a file"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create a test file
-    test_file = xtl_path / "test_file.txt"
+    test_file = tmp_path / "test_file.txt"
     test_file.write_text("test content")
 
     # Add and commit the file
     add_cmd = [git2cpp_path, "add", "test_file.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     commit_cmd = [git2cpp_path, "commit", "-m", "Add test file"]
-    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_commit.returncode == 0
 
     # Remove the file
     rm_cmd = [git2cpp_path, "rm", "test_file.txt"]
-    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_rm.returncode == 0
 
     # Verify the file was removed from working tree
@@ -31,35 +33,36 @@ def test_rm_basic_file(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
 
     # Check git status
     status_cmd = [git2cpp_path, "status", "--long"]
-    p_status = subprocess.run(status_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_status = subprocess.run(status_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_status.returncode == 0
     assert "Changes to be committed" in p_status.stdout
     assert "deleted" in p_status.stdout
 
 
-def test_rm_multiple_files(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rm_multiple_files(commit_env_config, git2cpp_path, tmp_path):
     """Test removing multiple files at once"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create test files
-    file1 = xtl_path / "file1.txt"
+    file1 = tmp_path / "file1.txt"
     file1.write_text("content 1")
-    file2 = xtl_path / "file2.txt"
+    file2 = tmp_path / "file2.txt"
     file2.write_text("content 2")
 
     # Add and commit files
     add_cmd = [git2cpp_path, "add", "file1.txt", "file2.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     commit_cmd = [git2cpp_path, "commit", "-m", "Add test files"]
-    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_commit.returncode == 0
 
     # Remove both files
     rm_cmd = [git2cpp_path, "rm", "file1.txt", "file2.txt"]
-    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_rm.returncode == 0
 
     # Verify both files were removed
@@ -68,35 +71,36 @@ def test_rm_multiple_files(xtl_clone, commit_env_config, git2cpp_path, tmp_path)
 
     # Check git status
     status_cmd = [git2cpp_path, "status", "--long"]
-    p_status = subprocess.run(status_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_status = subprocess.run(status_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_status.returncode == 0
     assert "Changes to be committed" in p_status.stdout
     assert "deleted" in p_status.stdout
 
 
-def test_rm_directory_without_recursive_flag(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rm_directory_without_recursive_flag(commit_env_config, git2cpp_path, tmp_path):
     """Test that rm fails when trying to remove a directory without -r flag"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create a directory with a file
-    test_dir = xtl_path / "test_dir"
+    test_dir = tmp_path / "test_dir"
     test_dir.mkdir()
     test_file = test_dir / "file.txt"
     test_file.write_text("content")
 
     # Add and commit the file
     add_cmd = [git2cpp_path, "add", "test_dir/file.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     commit_cmd = [git2cpp_path, "commit", "-m", "Add test directory"]
-    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_commit.returncode == 0
 
     # Try to remove directory without -r flag - should fail
     rm_cmd = [git2cpp_path, "rm", "test_dir"]
-    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_rm.returncode != 0
     assert "not removing" in p_rm.stderr and "recursively without -r" in p_rm.stderr
 
@@ -105,13 +109,14 @@ def test_rm_directory_without_recursive_flag(xtl_clone, commit_env_config, git2c
     assert test_file.exists()
 
 
-def test_rm_directory_with_recursive_flag(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rm_directory_with_recursive_flag(commit_env_config, git2cpp_path, tmp_path):
     """Test removing a directory with -r flag"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create a directory with files
-    test_dir = xtl_path / "test_dir"
+    test_dir = tmp_path / "test_dir"
     test_dir.mkdir()
     file1 = test_dir / "file1.txt"
     file1.write_text("content 1")
@@ -120,59 +125,62 @@ def test_rm_directory_with_recursive_flag(xtl_clone, commit_env_config, git2cpp_
 
     # Add and commit the files
     add_cmd = [git2cpp_path, "add", "test_dir/file1.txt", "test_dir/file2.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     commit_cmd = [git2cpp_path, "commit", "-m", "Add test directory"]
-    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_commit.returncode == 0
 
     # Remove directory with -r flag - should succeed
     rm_cmd = [git2cpp_path, "rm", "-r", "test_dir"]
-    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_rm.returncode == 0
 
     # Check git status
     status_cmd = [git2cpp_path, "status", "--long"]
-    p_status = subprocess.run(status_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_status = subprocess.run(status_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_status.returncode == 0
     assert "Changes to be committed" in p_status.stdout
     assert "deleted" in p_status.stdout
 
 
-def test_rm_and_commit(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rm_and_commit(commit_env_config, git2cpp_path, tmp_path):
     """Test removing a file and committing the change"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create a test file
-    test_file = xtl_path / "to_remove.txt"
+    test_file = tmp_path / "to_remove.txt"
     test_file.write_text("content to remove")
 
     # Add and commit the file
     add_cmd = [git2cpp_path, "add", "to_remove.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     commit_cmd = [git2cpp_path, "commit", "-m", "Add file to remove"]
-    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_commit.returncode == 0
 
     # Remove the file
     rm_cmd = [git2cpp_path, "rm", "to_remove.txt"]
-    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_rm.returncode == 0
 
     # Check status before commit
     status_cmd = [git2cpp_path, "status", "--long"]
-    p_status = subprocess.run(status_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_status = subprocess.run(status_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_status.returncode == 0
     assert "Changes to be committed" in p_status.stdout
     assert "deleted" in p_status.stdout
 
     # Commit the removal
     commit_cmd2 = [git2cpp_path, "commit", "-m", "Remove file"]
-    p_commit2 = subprocess.run(commit_cmd2, capture_output=True, cwd=xtl_path, text=True)
+    p_commit2 = subprocess.run(
+        commit_cmd2, capture_output=True, cwd=tmp_path, text=True
+    )
     assert p_commit2.returncode == 0
 
     # Verify the file is gone
@@ -180,54 +188,59 @@ def test_rm_and_commit(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
 
     # Check status after commit
     status_cmd2 = [git2cpp_path, "status", "--long"]
-    p_status2 = subprocess.run(status_cmd2, capture_output=True, cwd=xtl_path, text=True)
+    p_status2 = subprocess.run(
+        status_cmd2, capture_output=True, cwd=tmp_path, text=True
+    )
     assert p_status2.returncode == 0
     assert "to_remove.txt" not in p_status2.stdout
 
 
-def test_rm_nonexistent_file(xtl_clone, git2cpp_path, tmp_path):
+def test_rm_nonexistent_file(git2cpp_path, tmp_path):
     """Test that rm fails when file doesn't exist"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Try to remove a file that doesn't exist
     rm_cmd = [git2cpp_path, "rm", "nonexistent.txt"]
-    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_rm.returncode != 0
 
 
-def test_rm_untracked_file(xtl_clone, git2cpp_path, tmp_path):
+def test_rm_untracked_file(git2cpp_path, tmp_path):
     """Test that rm fails when trying to remove an untracked file"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create an untracked file
-    untracked_file = xtl_path / "untracked.txt"
+    untracked_file = tmp_path / "untracked.txt"
     untracked_file.write_text("untracked content")
 
     # Try to remove untracked file - should fail
     rm_cmd = [git2cpp_path, "rm", "untracked.txt"]
-    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_rm.returncode != 0
 
 
-def test_rm_staged_file(xtl_clone, git2cpp_path, tmp_path):
+def test_rm_staged_file(git2cpp_path, tmp_path):
     """Test removing a file that was added but not yet committed"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create a test file
-    test_file = xtl_path / "staged.txt"
+    test_file = tmp_path / "staged.txt"
     test_file.write_text("staged content")
 
     # Add the file (but don't commit)
     add_cmd = [git2cpp_path, "add", "staged.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     # Remove the file
     rm_cmd = [git2cpp_path, "rm", "staged.txt"]
-    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_rm.returncode == 0
 
     # Verify the file was removed
@@ -235,33 +248,36 @@ def test_rm_staged_file(xtl_clone, git2cpp_path, tmp_path):
 
     # Check git status - should show nothing staged
     status_cmd = [git2cpp_path, "status", "--long"]
-    p_status = subprocess.run(status_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_status = subprocess.run(status_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_status.returncode == 0
     assert "Changes to be committed" not in p_status.stdout
     assert "staged.txt" not in p_status.stdout
 
 
-def test_rm_file_in_subdirectory(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rm_file_in_subdirectory(commit_env_config, git2cpp_path, tmp_path):
     """Test removing a file in a subdirectory"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
-    # Use existing subdirectory
-    test_file = xtl_path / "include" / "test.txt"
+    # Create subdirectory
+    test_dir = tmp_path / "test"
+    test_dir.mkdir()
+    test_file = test_dir / "test.txt"
     test_file.write_text("test content")
 
     # Add and commit the file
-    add_cmd = [git2cpp_path, "add", "include/test.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    add_cmd = [git2cpp_path, "add", "test/test.txt"]
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     commit_cmd = [git2cpp_path, "commit", "-m", "Add file in subdirectory"]
-    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_commit.returncode == 0
 
     # Remove the file
-    rm_cmd = [git2cpp_path, "rm", "include/test.txt"]
-    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=xtl_path, text=True)
+    rm_cmd = [git2cpp_path, "rm", "test/test.txt"]
+    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_rm.returncode == 0
 
     # Verify the file was removed
@@ -269,7 +285,7 @@ def test_rm_file_in_subdirectory(xtl_clone, commit_env_config, git2cpp_path, tmp
 
     # Check git status
     status_cmd = [git2cpp_path, "status", "--long"]
-    p_status = subprocess.run(status_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_status = subprocess.run(status_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_status.returncode == 0
     assert "Changes to be committed" in p_status.stdout
     assert "deleted" in p_status.stdout
@@ -287,67 +303,69 @@ def test_rm_nogit(git2cpp_path, tmp_path):
     assert p_rm.returncode != 0
 
 
-def test_rm_nested_directory_recursive(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rm_nested_directory_recursive(commit_env_config, git2cpp_path, tmp_path):
     """Test removing a nested directory structure with -r flag"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create nested directory structure
-    nested_dir = xtl_path / "level1" / "level2"
+    nested_dir = tmp_path / "level1" / "level2"
     nested_dir.mkdir(parents=True)
-    file1 = xtl_path / "level1" / "file1.txt"
+    file1 = tmp_path / "level1" / "file1.txt"
     file1.write_text("content 1")
     file2 = nested_dir / "file2.txt"
     file2.write_text("content 2")
 
     # Add and commit the files
     add_cmd = [git2cpp_path, "add", "level1/file1.txt", "level1/level2/file2.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     commit_cmd = [git2cpp_path, "commit", "-m", "Add nested structure"]
-    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_commit.returncode == 0
 
     # Remove the directory tree with -r flag
     rm_cmd = [git2cpp_path, "rm", "-r", "level1"]
-    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_rm.returncode == 0
 
     # Check git status
     status_cmd = [git2cpp_path, "status", "--long"]
-    p_status = subprocess.run(status_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_status = subprocess.run(status_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_status.returncode == 0
     assert "Changes to be committed" in p_status.stdout
     assert "deleted" in p_status.stdout
 
 
-def test_rm_mixed_files_and_directory(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_rm_mixed_files_and_directory(commit_env_config, git2cpp_path, tmp_path):
     """Test removing both individual files and directories in one command"""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    cmd_init = [git2cpp_path, "init", "."]
+    p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path)
+    assert p_init.returncode == 0
 
     # Create a file and a directory with contents
-    single_file = xtl_path / "single.txt"
+    single_file = tmp_path / "single.txt"
     single_file.write_text("single file")
 
-    test_dir = xtl_path / "remove_dir"
+    test_dir = tmp_path / "remove_dir"
     test_dir.mkdir()
     dir_file = test_dir / "file.txt"
     dir_file.write_text("file in dir")
 
     # Add and commit everything
     add_cmd = [git2cpp_path, "add", "single.txt", "remove_dir/file.txt"]
-    p_add = subprocess.run(add_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_add = subprocess.run(add_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     commit_cmd = [git2cpp_path, "commit", "-m", "Add mixed content"]
-    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_commit = subprocess.run(commit_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_commit.returncode == 0
 
     # Remove both file and directory
     rm_cmd = [git2cpp_path, "rm", "-r", "single.txt", "remove_dir"]
-    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_rm = subprocess.run(rm_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_rm.returncode == 0
 
     # Verify everything was removed
@@ -355,7 +373,7 @@ def test_rm_mixed_files_and_directory(xtl_clone, commit_env_config, git2cpp_path
 
     # Check git status
     status_cmd = [git2cpp_path, "status", "--long"]
-    p_status = subprocess.run(status_cmd, capture_output=True, cwd=xtl_path, text=True)
+    p_status = subprocess.run(status_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_status.returncode == 0
     assert "Changes to be committed" in p_status.stdout
     assert "deleted" in p_status.stdout

--- a/test/test_stash.py
+++ b/test/test_stash.py
@@ -3,75 +3,74 @@ import subprocess
 import pytest
 
 
-def test_stash_push(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_stash_push(repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path):
+    assert (tmp_path / "initial.txt").exists()
 
-    p = xtl_path / "mook_file.txt"
+    p = tmp_path / "mook_file.txt"
     p.write_text("blabla")
 
     cmd_add = [git2cpp_path, "add", "mook_file.txt"]
-    p_add = subprocess.run(cmd_add, cwd=xtl_path, text=True)
+    p_add = subprocess.run(cmd_add, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
-    stash_path = xtl_path / ".git/refs/stash"
+    stash_path = tmp_path / ".git/refs/stash"
     assert not stash_path.exists()
 
     cmd_stash = [git2cpp_path, "stash"]
-    p_stash = subprocess.run(cmd_stash, capture_output=True, cwd=xtl_path, text=True)
+    p_stash = subprocess.run(cmd_stash, capture_output=True, cwd=tmp_path, text=True)
     assert p_stash.returncode == 0
     assert stash_path.exists()
 
 
-def test_stash_list(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_stash_list(repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path):
+    assert (tmp_path / "initial.txt").exists()
 
-    p = xtl_path / "mook_file.txt"
+    p = tmp_path / "mook_file.txt"
     p.write_text("blabla")
 
     cmd_add = [git2cpp_path, "add", "mook_file.txt"]
-    p_add = subprocess.run(cmd_add, cwd=xtl_path, text=True)
+    p_add = subprocess.run(cmd_add, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     cmd_list = [git2cpp_path, "stash", "list"]
-    p_list = subprocess.run(cmd_list, capture_output=True, cwd=xtl_path, text=True)
+    p_list = subprocess.run(cmd_list, capture_output=True, cwd=tmp_path, text=True)
     assert p_list.returncode == 0
     assert "stash@{0}" not in p_list.stdout
 
     cmd_stash = [git2cpp_path, "stash"]
-    p_stash = subprocess.run(cmd_stash, capture_output=True, cwd=xtl_path, text=True)
+    p_stash = subprocess.run(cmd_stash, capture_output=True, cwd=tmp_path, text=True)
     assert p_stash.returncode == 0
 
-    p_list_2 = subprocess.run(cmd_list, capture_output=True, cwd=xtl_path, text=True)
+    p_list_2 = subprocess.run(cmd_list, capture_output=True, cwd=tmp_path, text=True)
     assert p_list_2.returncode == 0
     assert "stash@{0}" in p_list_2.stdout
 
 
 @pytest.mark.parametrize("index_flag", ["", "--index"])
-def test_stash_pop(xtl_clone, commit_env_config, git2cpp_path, tmp_path, index_flag):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_stash_pop(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path, index_flag
+):
+    assert (tmp_path / "initial.txt").exists()
 
     index = 0 if index_flag == "" else 1
 
     for i in range(index + 1):
-        p = xtl_path / f"mook_file_{i}.txt"
+        p = tmp_path / f"mook_file_{i}.txt"
         p.write_text(f"blabla{i}")
 
         cmd_add = [git2cpp_path, "add", f"mook_file_{i}.txt"]
-        p_add = subprocess.run(cmd_add, cwd=xtl_path, text=True)
+        p_add = subprocess.run(cmd_add, cwd=tmp_path, text=True)
         assert p_add.returncode == 0
 
         cmd_stash = [git2cpp_path, "stash"]
         p_stash = subprocess.run(
-            cmd_stash, capture_output=True, cwd=xtl_path, text=True
+            cmd_stash, capture_output=True, cwd=tmp_path, text=True
         )
         assert p_stash.returncode == 0
 
         cmd_status = [git2cpp_path, "status"]
         p_status = subprocess.run(
-            cmd_status, capture_output=True, cwd=xtl_path, text=True
+            cmd_status, capture_output=True, cwd=tmp_path, text=True
         )
         assert p_status.returncode == 0
         assert "mook_file" not in p_status.stdout
@@ -80,13 +79,13 @@ def test_stash_pop(xtl_clone, commit_env_config, git2cpp_path, tmp_path, index_f
     if index_flag != "":
         cmd_pop.append(index_flag)
         cmd_pop.append("1")
-    p_pop = subprocess.run(cmd_pop, capture_output=True, cwd=xtl_path, text=True)
+    p_pop = subprocess.run(cmd_pop, capture_output=True, cwd=tmp_path, text=True)
     assert p_pop.returncode == 0
     assert "mook_file_0" in p_pop.stdout
     assert "Dropped refs/stash@{" + str(index) + "}" in p_pop.stdout
 
     cmd_list = [git2cpp_path, "stash", "list"]
-    p_list = subprocess.run(cmd_list, capture_output=True, cwd=xtl_path, text=True)
+    p_list = subprocess.run(cmd_list, capture_output=True, cwd=tmp_path, text=True)
     assert p_list.returncode == 0
     if index_flag == "":
         assert p_list.stdout == ""
@@ -96,29 +95,30 @@ def test_stash_pop(xtl_clone, commit_env_config, git2cpp_path, tmp_path, index_f
 
 
 @pytest.mark.parametrize("index_flag", ["", "--index"])
-def test_stash_apply(xtl_clone, commit_env_config, git2cpp_path, tmp_path, index_flag):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_stash_apply(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path, index_flag
+):
+    assert (tmp_path / "initial.txt").exists()
 
     index = 0 if index_flag == "" else 1
 
     for i in range(index + 1):
-        p = xtl_path / f"mook_file_{i}.txt"
+        p = tmp_path / f"mook_file_{i}.txt"
         p.write_text(f"blabla{i}")
 
         cmd_add = [git2cpp_path, "add", f"mook_file_{i}.txt"]
-        p_add = subprocess.run(cmd_add, cwd=xtl_path, text=True)
+        p_add = subprocess.run(cmd_add, cwd=tmp_path, text=True)
         assert p_add.returncode == 0
 
         cmd_stash = [git2cpp_path, "stash"]
         p_stash = subprocess.run(
-            cmd_stash, capture_output=True, cwd=xtl_path, text=True
+            cmd_stash, capture_output=True, cwd=tmp_path, text=True
         )
         assert p_stash.returncode == 0
 
         cmd_status = [git2cpp_path, "status"]
         p_status = subprocess.run(
-            cmd_status, capture_output=True, cwd=xtl_path, text=True
+            cmd_status, capture_output=True, cwd=tmp_path, text=True
         )
         assert p_status.returncode == 0
         assert "mook_file" not in p_status.stdout
@@ -127,36 +127,35 @@ def test_stash_apply(xtl_clone, commit_env_config, git2cpp_path, tmp_path, index
     if index_flag != "":
         cmd_apply.append(index_flag)
         cmd_apply.append("1")
-    p_apply = subprocess.run(cmd_apply, capture_output=True, cwd=xtl_path, text=True)
+    p_apply = subprocess.run(cmd_apply, capture_output=True, cwd=tmp_path, text=True)
     assert p_apply.returncode == 0
     assert "mook_file_0" in p_apply.stdout
 
     cmd_list = [git2cpp_path, "stash", "list"]
-    p_list = subprocess.run(cmd_list, capture_output=True, cwd=xtl_path, text=True)
+    p_list = subprocess.run(cmd_list, capture_output=True, cwd=tmp_path, text=True)
     assert p_list.returncode == 0
     assert "stash@{0}" in p_list.stdout
     if index_flag != "":
         assert "stash@{1}" in p_list.stdout
 
 
-def test_stash_show(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_stash_show(repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path):
+    assert (tmp_path / "initial.txt").exists()
 
     filename = "mook_show.txt"
-    p = xtl_path / filename
+    p = tmp_path / filename
     p.write_text("Hello")
 
     cmd_add = [git2cpp_path, "add", filename]
-    p_add = subprocess.run(cmd_add, cwd=xtl_path, text=True)
+    p_add = subprocess.run(cmd_add, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     cmd_stash = [git2cpp_path, "stash"]
-    p_stash = subprocess.run(cmd_stash, capture_output=True, cwd=xtl_path, text=True)
+    p_stash = subprocess.run(cmd_stash, capture_output=True, cwd=tmp_path, text=True)
     assert p_stash.returncode == 0
 
     cmd_show = [git2cpp_path, "stash", "show", "--stat"]
-    p_show = subprocess.run(cmd_show, capture_output=True, cwd=xtl_path, text=True)
+    p_show = subprocess.run(cmd_show, capture_output=True, cwd=tmp_path, text=True)
     assert p_show.returncode == 0
 
     # A diffstat should mention the file and summary "file changed"

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -7,27 +7,42 @@ import pytest
 
 @pytest.mark.parametrize("short_flag", ["", "-s", "--short"])
 @pytest.mark.parametrize("long_flag", ["", "--long"])
-def test_status_new_file(xtl_clone, git2cpp_path, tmp_path, short_flag, long_flag):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_status_new_file(
+    repo_init_with_commit, git2cpp_path, tmp_path, short_flag, long_flag
+):
+    assert (tmp_path / "initial.txt").exists()
 
-    p = xtl_path / "mook_file.txt"  # Untracked files
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
+
+    p = tmp_path / "mook_file.txt"  # Untracked files
     p.write_text("")
 
-    pw = xtl_path / "CMakeLists.txt"  # Changes not staged for commit / modified
+    pw = tmp_path / "initial.txt"  # Changes not staged for commit / modified
     pw.write_text("blablabla")
 
-    os.remove(xtl_path / "README.md")  # Changes not staged for commit / deleted
+    deletable = tmp_path / "to_delete.txt"
+    deletable.write_text("delete me")
+    subprocess.run([git2cpp_path, "add", "to_delete.txt"], cwd=tmp_path, check=True)
+    subprocess.run(
+        [git2cpp_path, "commit", "-m", "Add deletable"], cwd=tmp_path, check=True
+    )
+    os.remove(deletable)  # Changes not staged for commit / deleted
 
     cmd = [git2cpp_path, "status"]
     if short_flag != "":
         cmd.append(short_flag)
     if long_flag != "":
         cmd.append(long_flag)
-    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True, check=True)
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True, check=True)
 
     if (long_flag == "--long") or ((long_flag == "") & (short_flag == "")):
-        assert "On branch master" in p.stdout
+        assert f"On branch {default_branch}" in p.stdout
         assert "Changes not staged for commit" in p.stdout
         assert "Untracked files" in p.stdout
         assert "deleted" in p.stdout
@@ -48,17 +63,18 @@ def test_status_nogit(git2cpp_path, tmp_path):
 
 @pytest.mark.parametrize("short_flag", ["", "-s", "--short"])
 @pytest.mark.parametrize("long_flag", ["", "--long"])
-def test_status_add_file(xtl_clone, git2cpp_path, tmp_path, short_flag, long_flag):
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+def test_status_add_file(
+    repo_init_with_commit, git2cpp_path, tmp_path, short_flag, long_flag
+):
+    assert (tmp_path / "initial.txt").exists()
 
-    p = xtl_path / "mook_file.txt"  # Changes to be committed / new file
+    p = tmp_path / "mook_file.txt"  # Changes to be committed / new file
     p.write_text("")
 
-    os.remove(xtl_path / "README.md")  # Changes to be committed / deleted
+    os.remove(tmp_path / "initial.txt")  # Changes to be committed / deleted
 
     cmd_add = [git2cpp_path, "add", "--all"]
-    p_add = subprocess.run(cmd_add, cwd=xtl_path, text=True)
+    p_add = subprocess.run(cmd_add, cwd=tmp_path, text=True)
     assert p_add.returncode == 0
 
     cmd_status = [git2cpp_path, "status"]
@@ -66,7 +82,7 @@ def test_status_add_file(xtl_clone, git2cpp_path, tmp_path, short_flag, long_fla
         cmd_status.append(short_flag)
     if long_flag != "":
         cmd_status.append(long_flag)
-    p_status = subprocess.run(cmd_status, capture_output=True, cwd=xtl_path, text=True)
+    p_status = subprocess.run(cmd_status, capture_output=True, cwd=tmp_path, text=True)
     assert p_status.returncode == 0
 
     if (long_flag == "--long") or ((long_flag == "") & (short_flag == "")):
@@ -89,56 +105,82 @@ def test_status_new_repo(git2cpp_path, tmp_path, run_in_tmp_path):
     p = subprocess.run(cmd, cwd=tmp_path)
     assert p.returncode == 0
 
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
+    print(default_branch)
+
     cmd_status = [git2cpp_path, "status"]
     p_status = subprocess.run(cmd_status, capture_output=True, cwd=tmp_path, text=True)
     assert p_status.returncode == 0
-    assert "On branch ma" in p_status.stdout   # "main" locally, but "master" in the CI
+    assert f"On branch {default_branch}" in p_status.stdout
     assert "No commit yet" in p_status.stdout
     assert "Nothing to commit, working tree clean" in p_status.stdout
 
 
-def test_status_clean_tree(xtl_clone, git2cpp_path, tmp_path):
+def test_status_clean_tree(repo_init_with_commit, git2cpp_path, tmp_path):
     """Test 'Nothing to commit, working tree clean' message"""
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     cmd = [git2cpp_path, "status"]
-    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
 
     assert p.returncode == 0
-    assert "On branch master" in p.stdout
+    assert f"On branch {default_branch}" in p.stdout
     assert "Nothing to commit, working tree clean" in p.stdout
 
 
 @pytest.mark.parametrize("short_flag", ["", "-s"])
-def test_status_rename_detection(xtl_clone, git2cpp_path, tmp_path, short_flag):
+def test_status_rename_detection(
+    repo_init_with_commit, git2cpp_path, tmp_path, short_flag
+):
     """Test that renamed files are detected correctly"""
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
-    # Rename a file using git mv or by moving and staging
-    old_readme = xtl_path / "README.md"
-    new_readme = xtl_path / "README_renamed.md"
+    # Create tracked file to rename
+    new_file = tmp_path / "other_file.txt"
+    new_file.write_text("Another file")
+    subprocess.run([git2cpp_path, "add", "other_file.txt"], cwd=tmp_path, check=True)
+    subprocess.run(
+        [git2cpp_path, "commit", "-m", "Add file to rename"], cwd=tmp_path, check=True
+    )
 
-    # Move the README file
-    os.rename(old_readme, new_readme)
+    # Rename a file by moving and staging
+    # Move the initial file
+    old_name = tmp_path / "initial.txt"
+    new_name = tmp_path / "initial_renamed.txt"
+    os.rename(old_name, new_name)
 
-    # Move/rename the LICENCE file using mv
-    cmd_mv = [git2cpp_path, "mv", "LICENSE", "LICENSE_renamed"]
-    subprocess.run(cmd_mv, capture_output=True, cwd=xtl_path, check=True)
+    # Move/rename the other file using mv
+    cmd_mv = [git2cpp_path, "mv", "other_file.txt", "other_file_renamed.txt"]
+    subprocess.run(cmd_mv, capture_output=True, cwd=tmp_path, check=True)
 
     # Stage both the deletion and addition
     cmd_add = [git2cpp_path, "add", "--all"]
-    subprocess.run(cmd_add, capture_output=True, cwd=xtl_path, check=True)
+    subprocess.run(cmd_add, capture_output=True, cwd=tmp_path, check=True)
 
     # Check status
     cmd_status = [git2cpp_path, "status"]
     if short_flag == "-s":
         cmd_status.append(short_flag)
-    p = subprocess.run(cmd_status, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd_status, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
 
     # Should show as renamed, not as deleted + new file
-    assert "README.md -> README_renamed.md" in p.stdout
-    assert "LICENSE -> LICENSE_renamed" in p.stdout
+    assert "initial.txt -> initial_renamed.txt" in p.stdout
+    assert "other_file.txt -> other_file_renamed.txt" in p.stdout
     if short_flag == "-s":
         assert "R  " in p.stdout
     else:
@@ -146,64 +188,78 @@ def test_status_rename_detection(xtl_clone, git2cpp_path, tmp_path, short_flag):
 
 
 @pytest.mark.parametrize("short_flag", ["", "-s"])
-def test_status_mixed_changes(xtl_clone, git2cpp_path, tmp_path, short_flag):
+def test_status_mixed_changes(
+    repo_init_with_commit, git2cpp_path, tmp_path, short_flag
+):
     """Test status with both staged and unstaged changes"""
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     # Create a new file and stage it
-    staged_file = xtl_path / "staged.txt"
+    staged_file = tmp_path / "staged.txt"
     staged_file.write_text("staged content")
 
-    # Deleted a file staged
-    del_file = xtl_path / "README.md"
+    # Create a tracked file, then delete it (and stage the deletion)
+    del_file = tmp_path / "to_delete.txt"
+    del_file.write_text("delete me")
+    subprocess.run([git2cpp_path, "add", "to_delete.txt"], cwd=tmp_path, check=True)
+    subprocess.run(
+        [git2cpp_path, "commit", "-m", "Add deletable"], cwd=tmp_path, check=True
+    )
     os.remove(del_file)
 
     # Stage the two previous files
-    subprocess.run([git2cpp_path, "add", "staged.txt", "README.md"], cwd=xtl_path, check=True)
+    subprocess.run(
+        [git2cpp_path, "add", "staged.txt", "to_delete.txt"], cwd=tmp_path, check=True
+    )
 
     # Modify an existing file without staging
-    unstaged_file = xtl_path / "CMakeLists.txt"
+    unstaged_file = tmp_path / "initial.txt"
     unstaged_file.write_text("unstaged changes")
 
     # Create an untracked file
-    untracked_file = xtl_path / "untracked.txt"
+    untracked_file = tmp_path / "untracked.txt"
     untracked_file.write_text("untracked")
 
     cmd_status = [git2cpp_path, "status"]
     if short_flag == "-s":
         cmd_status.append(short_flag)
-    p = subprocess.run(cmd_status, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd_status, capture_output=True, cwd=tmp_path, text=True)
 
     assert p.returncode == 0
     if short_flag == "-s":
         assert "A  staged.txt" in p.stdout
-        assert "D  README.md" in p.stdout
-        assert " M CMakeLists.txt" in p.stdout
+        assert "D  to_delete.txt" in p.stdout
+        assert " M initial.txt" in p.stdout
         assert "?? untracked.txt" in p.stdout
     else:
         assert "Changes to be committed" in p.stdout
         assert "new file:   staged.txt" in p.stdout
-        assert "deleted:   README.md" in p.stdout
+        assert "deleted:   to_delete.txt" in p.stdout
         assert "Changes not staged for commit" in p.stdout
-        assert "modified:   CMakeLists.txt" in p.stdout
+        assert "modified:   initial.txt" in p.stdout
         assert "Untracked files" in p.stdout
         assert "untracked.txt" in p.stdout
 
 
 @pytest.mark.parametrize("short_flag", ["", "-s"])
-def test_status_typechange(xtl_clone, git2cpp_path, tmp_path, short_flag):
+def test_status_typechange(repo_init_with_commit, git2cpp_path, tmp_path, short_flag):
     """Test status shows typechange (file to symlink or vice versa)"""
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     # Remove a file and replace with a symlink
-    test_file = xtl_path / "README.md"
+    test_file = tmp_path / "typechange"
+    test_file.write_text("regular file")
+    subprocess.run([git2cpp_path, "add", "typechange"], cwd=tmp_path, check=True)
+    subprocess.run(
+        [git2cpp_path, "commit", "-m", "Add typechange"], cwd=tmp_path, check=True
+    )
     os.remove(test_file)
-    os.symlink("CMakeLists.txt", test_file)
+    os.symlink("initial.txt", test_file)
 
     cmd_status = [git2cpp_path, "status"]
     if short_flag == "-s":
         cmd_status.append(short_flag)
-    p = subprocess.run(cmd_status, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd_status, capture_output=True, cwd=tmp_path, text=True)
 
     assert p.returncode == 0
     # Should show typechange in unstaged changes
@@ -214,12 +270,14 @@ def test_status_typechange(xtl_clone, git2cpp_path, tmp_path, short_flag):
 
 
 @pytest.mark.parametrize("short_flag", ["", "-s"])
-def test_status_untracked_directory(xtl_clone, git2cpp_path, tmp_path, short_flag):
+def test_status_untracked_directory(
+    repo_init_with_commit, git2cpp_path, tmp_path, short_flag
+):
     """Test that untracked directories are shown with trailing slash"""
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     # Create a directory with files
-    new_dir = xtl_path / "new_directory"
+    new_dir = tmp_path / "new_directory"
     new_dir.mkdir()
     (new_dir / "file1.txt").write_text("content1")
     (new_dir / "file2.txt").write_text("content2")
@@ -227,7 +285,7 @@ def test_status_untracked_directory(xtl_clone, git2cpp_path, tmp_path, short_fla
     cmd_status = [git2cpp_path, "status"]
     if short_flag == "-s":
         cmd_status.append(short_flag)
-    p = subprocess.run(cmd_status, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd_status, capture_output=True, cwd=tmp_path, text=True)
 
     assert p.returncode == 0
     if short_flag == "-s":
@@ -241,7 +299,9 @@ def test_status_untracked_directory(xtl_clone, git2cpp_path, tmp_path, short_fla
 
 
 @pytest.mark.parametrize("short_flag", ["", "-s"])
-def test_status_ahead_of_upstream(commit_env_config, git2cpp_path, tmp_path, short_flag):
+def test_status_ahead_of_upstream(
+    commit_env_config, git2cpp_path, tmp_path, short_flag
+):
     """Test status when local branch is ahead of upstream"""
     # Create a repository with remote tracking
     repo_path = tmp_path / "repo"
@@ -249,6 +309,14 @@ def test_status_ahead_of_upstream(commit_env_config, git2cpp_path, tmp_path, sho
 
     # Initialize repo
     subprocess.run([git2cpp_path, "init"], cwd=repo_path, check=True)
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=repo_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     # Create initial commit
     test_file = repo_path / "file.txt"
@@ -258,39 +326,52 @@ def test_status_ahead_of_upstream(commit_env_config, git2cpp_path, tmp_path, sho
 
     # Clone it to create remote tracking
     clone_path = tmp_path / "clone"
-    subprocess.run(["git", "clone", str(repo_path), str(clone_path)], check=True)
+    subprocess.run([git2cpp_path, "clone", str(repo_path), str(clone_path)], check=True)
 
     # Make a commit in clone
     clone_file = clone_path / "file2.txt"
     clone_file.write_text("new file")
     subprocess.run([git2cpp_path, "add", "file2.txt"], cwd=clone_path, check=True)
-    subprocess.run([git2cpp_path, "commit", "-m", "second commit"], cwd=clone_path, check=True)
+    subprocess.run(
+        [git2cpp_path, "commit", "-m", "second commit"], cwd=clone_path, check=True
+    )
 
     # Check status
     cmd_status = [git2cpp_path, "status"]
-    if (short_flag == "-s"):
+    if short_flag == "-s":
         cmd_status.append(short_flag)
     p = subprocess.run(cmd_status, capture_output=True, cwd=clone_path, text=True)
 
     assert p.returncode == 0
     if short_flag == "-s":
-        assert "...origin/ma" in p.stdout   # "main" locally, but "master" in the CI
+        assert f"...origin/{default_branch}" in p.stdout
         assert "[ahead 1]" in p.stdout
     else:
-        assert "Your branch is ahead of" in p.stdout
+        assert f"Your branch is ahead of 'origin/{default_branch}'" in p.stdout
         assert "by 1 commit" in p.stdout
         assert 'use "git push"' in p.stdout
 
 
 @pytest.mark.parametrize("short_flag", ["", "-s"])
 @pytest.mark.parametrize("branch_flag", ["-b", "--branch"])
-def test_status_with_branch_and_tracking(commit_env_config, git2cpp_path, tmp_path, short_flag, branch_flag):
+def test_status_with_branch_and_tracking(
+    commit_env_config, git2cpp_path, tmp_path, short_flag, branch_flag
+):
     """Test short format with branch flag shows tracking info"""
     # Create a repository with remote tracking
     repo_path = tmp_path / "repo"
     repo_path.mkdir()
 
     subprocess.run([git2cpp_path, "init"], cwd=repo_path)
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=repo_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
+
     test_file = repo_path / "file.txt"
     test_file.write_text("initial")
     subprocess.run([git2cpp_path, "add", "file.txt"], cwd=repo_path, check=True)
@@ -298,7 +379,7 @@ def test_status_with_branch_and_tracking(commit_env_config, git2cpp_path, tmp_pa
 
     # Clone it
     clone_path = tmp_path / "clone"
-    subprocess.run(["git", "clone", str(repo_path), str(clone_path)], check=True)
+    subprocess.run([git2cpp_path, "clone", str(repo_path), str(clone_path)], check=True)
 
     # Make a commit
     clone_file = clone_path / "file2.txt"
@@ -314,36 +395,50 @@ def test_status_with_branch_and_tracking(commit_env_config, git2cpp_path, tmp_pa
 
     assert p.returncode == 0
     if short_flag == "-s":
-        assert "## ma" in p.stdout   # "main" locally, but "master" in the CI
+        assert (
+            f"## {default_branch}" in p.stdout
+        )  # "main" locally, but "master" in the CI
         assert "[ahead 1]" in p.stdout
     else:
-        assert "On branch ma" in p.stdout   # "main" locally, but "master" in the CI
-        assert "Your branch is ahead of 'origin/ma" in p.stdout   # "main" locally, but "master" in the CI
+        assert (
+            f"On branch {default_branch}" in p.stdout
+        )  # "main" locally, but "master" in the CI
+        assert (
+            f"Your branch is ahead of 'origin/{default_branch}'" in p.stdout
+        )  # "main" locally, but "master" in the CI
         assert "1 commit." in p.stdout
 
 
-def test_status_all_headers_shown(xtl_clone, git2cpp_path, tmp_path):
+def test_status_all_headers_shown(repo_init_with_commit, git2cpp_path, tmp_path):
     """Test that all status headers can be shown together"""
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
+
+    default_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        cwd=tmp_path,
+        text=True,
+        check=True,
+    ).stdout.strip()  # TODO: use git2cpp when "branch --show-current" is implemented
 
     # Changes to be committed
-    staged = xtl_path / "staged.txt"
+    staged = tmp_path / "staged.txt"
     staged.write_text("staged")
-    subprocess.run([git2cpp_path, "add", "staged.txt"], cwd=xtl_path, check=True)
+    subprocess.run([git2cpp_path, "add", "staged.txt"], cwd=tmp_path, check=True)
 
     # Changes not staged
-    modified = xtl_path / "CMakeLists.txt"
+    modified = tmp_path / "initial.txt"
     modified.write_text("modified")
 
     # Untracked
-    untracked = xtl_path / "untracked.txt"
+    untracked = tmp_path / "untracked.txt"
     untracked.write_text("untracked")
 
     cmd_status = [git2cpp_path, "status"]
-    p = subprocess.run(cmd_status, capture_output=True, cwd=xtl_path, text=True)
+    p = subprocess.run(cmd_status, capture_output=True, cwd=tmp_path, text=True)
 
     assert p.returncode == 0
-    assert "On branch master" in p.stdout
+    assert f"On branch {default_branch}" in p.stdout
     assert "Changes to be committed:" in p.stdout
     assert 'use "git reset HEAD <file>..." to unstage' in p.stdout
     assert "Changes not staged for commit:" in p.stdout

--- a/test/test_tag.py
+++ b/test/test_tag.py
@@ -2,91 +2,100 @@ import subprocess
 
 import pytest
 
-def test_tag_list_empty(xtl_clone, git2cpp_path, tmp_path):
+
+def test_tag_list_empty(repo_init_with_commit, git2cpp_path, tmp_path):
     """Test listing tags when there are no tags."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
-    cmd = [git2cpp_path, 'tag']
-    p = subprocess.run(cmd, capture_output=True, cwd=xtl_path, text=True)
+    cmd = [git2cpp_path, "tag"]
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
-    assert "0.2.0" in p.stdout
+    assert p.stdout == ""
 
 
-def test_tag_create_lightweight(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_tag_create_lightweight(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test creating a lightweight tag."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     # Create a lightweight tag
-    create_cmd = [git2cpp_path, 'tag', 'v1.0.0']
-    subprocess.run(create_cmd, capture_output=True, cwd=xtl_path, text=True, check=True)
+    create_cmd = [git2cpp_path, "tag", "v1.0.0"]
+    subprocess.run(create_cmd, capture_output=True, cwd=tmp_path, text=True, check=True)
 
     # List tags to verify it was created
-    list_cmd = [git2cpp_path, 'tag']
-    p_list = subprocess.run(list_cmd, capture_output=True, cwd=xtl_path, text=True)
+    list_cmd = [git2cpp_path, "tag"]
+    p_list = subprocess.run(list_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_list.returncode == 0
-    assert 'v1.0.0' in p_list.stdout
+    assert "v1.0.0" in p_list.stdout
 
 
-def test_tag_create_annotated(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_tag_create_annotated(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test creating an annotated tag."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     # Create an annotated tag
-    create_cmd = [git2cpp_path, 'tag', '-m', 'Release version 1.0', 'v1.0.0']
-    subprocess.run(create_cmd, capture_output=True, cwd=xtl_path, text=True, check=True)
+    create_cmd = [git2cpp_path, "tag", "-m", "Release version 1.0", "v1.0.0"]
+    subprocess.run(create_cmd, capture_output=True, cwd=tmp_path, text=True, check=True)
 
     # List tags to verify it was created
-    list_cmd = [git2cpp_path, 'tag', "-n", "1"]
-    p_list = subprocess.run(list_cmd, capture_output=True, cwd=xtl_path, text=True)
+    list_cmd = [git2cpp_path, "tag", "-n", "1"]
+    p_list = subprocess.run(list_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_list.returncode == 0
-    assert 'v1.0.0' in p_list.stdout
-    assert 'Release version 1.0' in p_list.stdout
+    assert "v1.0.0" in p_list.stdout
+    assert "Release version 1.0" in p_list.stdout
 
 
-def test_tag_create_on_specific_commit(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_tag_create_on_specific_commit(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test creating a tag on a specific commit."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     # Get the commit SHA before creating new commit
-    old_head_cmd = ['git', 'rev-parse', 'HEAD']
-    p_old_head = subprocess.run(old_head_cmd, capture_output=True, cwd=xtl_path, text=True)
+    old_head_cmd = ["git", "rev-parse", "HEAD"]
+    p_old_head = subprocess.run(
+        old_head_cmd, capture_output=True, cwd=tmp_path, text=True
+    )
     old_head_sha = p_old_head.stdout.strip()
 
     # Create a commit first
-    file_path = xtl_path / "test_file.txt"
+    file_path = tmp_path / "test_file.txt"
     file_path.write_text("test content")
 
-    add_cmd = [git2cpp_path, 'add', 'test_file.txt']
-    subprocess.run(add_cmd, cwd=xtl_path, check=True)
+    add_cmd = [git2cpp_path, "add", "test_file.txt"]
+    subprocess.run(add_cmd, cwd=tmp_path, check=True)
 
-    commit_cmd = [git2cpp_path, 'commit', '-m', 'test commit']
-    subprocess.run(commit_cmd, cwd=xtl_path, check=True)
+    commit_cmd = [git2cpp_path, "commit", "-m", "test commit"]
+    subprocess.run(commit_cmd, cwd=tmp_path, check=True)
 
     # Get new HEAD commit SHA
-    new_head_cmd = ['git', 'rev-parse', 'HEAD']
-    p_new_head = subprocess.run(new_head_cmd, capture_output=True, cwd=xtl_path, text=True)
+    new_head_cmd = ["git", "rev-parse", "HEAD"]
+    p_new_head = subprocess.run(
+        new_head_cmd, capture_output=True, cwd=tmp_path, text=True
+    )
     new_head_sha = p_new_head.stdout.strip()
 
     # Verify we actually created a new commit
     assert old_head_sha != new_head_sha
 
     # Create tag on HEAD
-    tag_cmd = [git2cpp_path, 'tag', 'v1.0.0', 'HEAD']
-    subprocess.run(tag_cmd, capture_output=True, cwd=xtl_path, check=True)
+    tag_cmd = [git2cpp_path, "tag", "v1.0.0", "HEAD"]
+    subprocess.run(tag_cmd, capture_output=True, cwd=tmp_path, check=True)
 
     # Verify tag exists
-    list_cmd = [git2cpp_path, 'tag']
-    p_list = subprocess.run(list_cmd, capture_output=True, cwd=xtl_path, text=True)
+    list_cmd = [git2cpp_path, "tag"]
+    p_list = subprocess.run(list_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_list.returncode == 0
-    assert 'v1.0.0' in p_list.stdout
+    assert "v1.0.0" in p_list.stdout
 
     # Get commit SHA that the tag points to
-    tag_sha_cmd = ['git', 'rev-parse', 'v1.0.0^{commit}']
-    p_tag_sha = subprocess.run(tag_sha_cmd, capture_output=True, cwd=xtl_path, text=True)
+    tag_sha_cmd = ["git", "rev-parse", "v1.0.0^{commit}"]
+    p_tag_sha = subprocess.run(
+        tag_sha_cmd, capture_output=True, cwd=tmp_path, text=True
+    )
     tag_sha = p_tag_sha.stdout.strip()
 
     # Verify tag points to new HEAD, not old HEAD
@@ -94,172 +103,186 @@ def test_tag_create_on_specific_commit(xtl_clone, commit_env_config, git2cpp_pat
     assert tag_sha != old_head_sha
 
 
-def test_tag_delete(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_tag_delete(repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path):
     """Test deleting a tag."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     # Create a tag
-    create_cmd = [git2cpp_path, 'tag', 'v1.0.0']
-    subprocess.run(create_cmd, capture_output=True, cwd=xtl_path, text=True, check=True)
+    create_cmd = [git2cpp_path, "tag", "v1.0.0"]
+    subprocess.run(create_cmd, capture_output=True, cwd=tmp_path, text=True, check=True)
 
     # Delete the tag
-    delete_cmd = [git2cpp_path, 'tag', '-d', 'v1.0.0']
-    p_delete = subprocess.run(delete_cmd, capture_output=True, cwd=xtl_path, text=True)
+    delete_cmd = [git2cpp_path, "tag", "-d", "v1.0.0"]
+    p_delete = subprocess.run(delete_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_delete.returncode == 0
     assert "Deleted tag 'v1.0.0'" in p_delete.stdout
 
     # Verify tag is gone
-    list_cmd = [git2cpp_path, 'tag']
-    p_list = subprocess.run(list_cmd, capture_output=True, cwd=xtl_path, text=True)
+    list_cmd = [git2cpp_path, "tag"]
+    p_list = subprocess.run(list_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_list.returncode == 0
-    assert 'v1.0.0' not in p_list.stdout
+    assert "v1.0.0" not in p_list.stdout
 
 
-def test_tag_delete_nonexistent(xtl_clone, git2cpp_path, tmp_path):
+def test_tag_delete_nonexistent(repo_init_with_commit, git2cpp_path, tmp_path):
     """Test deleting a tag that doesn't exist."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     # Try to delete non-existent tag
-    delete_cmd = [git2cpp_path, 'tag', '-d', 'nonexistent']
-    p_delete = subprocess.run(delete_cmd, capture_output=True, cwd=xtl_path, text=True)
+    delete_cmd = [git2cpp_path, "tag", "-d", "nonexistent"]
+    p_delete = subprocess.run(delete_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_delete.returncode != 0
     assert "not found" in p_delete.stderr
 
 
 @pytest.mark.parametrize("list_flag", ["-l", "--list"])
-def test_tag_list_with_flag(xtl_clone, commit_env_config, git2cpp_path, tmp_path, list_flag):
+def test_tag_list_with_flag(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path, list_flag
+):
     """Test listing tags with -l or --list flag."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     # Create a tag
-    tag_cmd = [git2cpp_path, 'tag', 'v1.0.0']
-    subprocess.run(tag_cmd, capture_output=True, cwd=xtl_path, text=True)
+    tag_cmd = [git2cpp_path, "tag", "v1.0.0"]
+    subprocess.run(tag_cmd, capture_output=True, cwd=tmp_path, text=True)
 
     # List tags
-    list_cmd = [git2cpp_path, 'tag', list_flag]
-    p_list = subprocess.run(list_cmd, capture_output=True, cwd=xtl_path, text=True)
+    list_cmd = [git2cpp_path, "tag", list_flag]
+    p_list = subprocess.run(list_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_list.returncode == 0
-    assert 'v1.0.0' in p_list.stdout
+    assert "v1.0.0" in p_list.stdout
 
 
-def test_tag_list_with_pattern(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_tag_list_with_pattern(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test listing tags with a pattern."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     # Create tags with different prefixes
-    tag_cmd_1 = [git2cpp_path, 'tag', 'v1.0.0']
-    subprocess.run(tag_cmd_1, capture_output=True, cwd=xtl_path, text=True)
+    tag_cmd_1 = [git2cpp_path, "tag", "v1.0.0"]
+    subprocess.run(tag_cmd_1, capture_output=True, cwd=tmp_path, text=True)
 
-    tag_cmd_2 = [git2cpp_path, 'tag', 'v1.0.1']
-    subprocess.run(tag_cmd_2, capture_output=True, cwd=xtl_path, text=True)
+    tag_cmd_2 = [git2cpp_path, "tag", "v1.0.1"]
+    subprocess.run(tag_cmd_2, capture_output=True, cwd=tmp_path, text=True)
 
-    tag_cmd_3 = [git2cpp_path, 'tag', 'release-1.0']
-    subprocess.run(tag_cmd_3, capture_output=True, cwd=xtl_path, text=True)
+    tag_cmd_3 = [git2cpp_path, "tag", "release-1.0"]
+    subprocess.run(tag_cmd_3, capture_output=True, cwd=tmp_path, text=True)
 
     # List only tags matching pattern
-    list_cmd = [git2cpp_path, 'tag', '-l', 'v1.0*']
-    p_list = subprocess.run(list_cmd, capture_output=True, cwd=xtl_path, text=True)
+    list_cmd = [git2cpp_path, "tag", "-l", "v1.0*"]
+    p_list = subprocess.run(list_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_list.returncode == 0
-    assert 'v1.0.0' in p_list.stdout
-    assert 'v1.0.1' in p_list.stdout
-    assert 'release-1.0' not in p_list.stdout
+    assert "v1.0.0" in p_list.stdout
+    assert "v1.0.1" in p_list.stdout
+    assert "release-1.0" not in p_list.stdout
 
 
-def test_tag_list_with_message_lines(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_tag_list_with_message_lines(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test listing tags with message lines (-n flag)."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     # Create an annotated tag with a message
-    create_cmd = [git2cpp_path, 'tag', '-m', 'First line\nSecond line\nThird line\nForth line', 'v1.0.0']
-    p_create = subprocess.run(create_cmd, capture_output=True, cwd=xtl_path, text=True)
+    create_cmd = [
+        git2cpp_path,
+        "tag",
+        "-m",
+        "First line\nSecond line\nThird line\nForth line",
+        "v1.0.0",
+    ]
+    p_create = subprocess.run(create_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_create.returncode == 0
 
     # List tags with message lines
-    list_cmd = [git2cpp_path, 'tag', '-n', '3', '-l']
-    p_list = subprocess.run(list_cmd, capture_output=True, cwd=xtl_path, text=True)
+    list_cmd = [git2cpp_path, "tag", "-n", "3", "-l"]
+    p_list = subprocess.run(list_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_list.returncode == 0
-    assert 'v1.0.0' in p_list.stdout
-    assert 'First line' in p_list.stdout
-    assert 'Second line' in p_list.stdout
-    assert 'Third line' in p_list.stdout
-    assert 'Forth line' not in p_list.stdout
+    assert "v1.0.0" in p_list.stdout
+    assert "First line" in p_list.stdout
+    assert "Second line" in p_list.stdout
+    assert "Third line" in p_list.stdout
+    assert "Forth line" not in p_list.stdout
 
 
 @pytest.mark.parametrize("force_flag", ["-f", "--force"])
-def test_tag_force_replace(xtl_clone, commit_env_config, git2cpp_path, tmp_path, force_flag):
+def test_tag_force_replace(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path, force_flag
+):
     """Test replacing an existing tag with -f or --force flag."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     # Create initial tag
-    create_cmd_1 = [git2cpp_path, 'tag', 'v1.0.0']
-    subprocess.run(create_cmd_1, capture_output=True, cwd=xtl_path, text=True, check=True)
+    create_cmd_1 = [git2cpp_path, "tag", "v1.0.0"]
+    subprocess.run(
+        create_cmd_1, capture_output=True, cwd=tmp_path, text=True, check=True
+    )
 
     # Try to create same tag without force (should fail)
-    create_cmd_2 = [git2cpp_path, 'tag', 'v1.0.0']
-    p_create_2 = subprocess.run(create_cmd_2, capture_output=True, cwd=xtl_path)
+    create_cmd_2 = [git2cpp_path, "tag", "v1.0.0"]
+    p_create_2 = subprocess.run(create_cmd_2, capture_output=True, cwd=tmp_path)
     assert p_create_2.returncode != 0
 
     # Create same tag with force (should succeed)
-    create_cmd_3 = [git2cpp_path, 'tag', force_flag, 'v1.0.0']
-    p_create_3 = subprocess.run(create_cmd_3, capture_output=True, cwd=xtl_path, text=True)
+    create_cmd_3 = [git2cpp_path, "tag", force_flag, "v1.0.0"]
+    p_create_3 = subprocess.run(
+        create_cmd_3, capture_output=True, cwd=tmp_path, text=True
+    )
     assert p_create_3.returncode == 0
 
 
 def test_tag_nogit(git2cpp_path, tmp_path):
     """Test tag command outside a git repository."""
-    cmd = [git2cpp_path, 'tag']
+    cmd = [git2cpp_path, "tag"]
     p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode != 0
 
 
-def test_tag_annotated_no_message(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_tag_annotated_no_message(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test creating an annotated tag without a message should fail."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     # Create a commit with a known message
-    file_path = xtl_path / "test_file.txt"
+    file_path = tmp_path / "test_file.txt"
     file_path.write_text("test content")
 
-    add_cmd = [git2cpp_path, 'add', 'test_file.txt']
-    subprocess.run(add_cmd, cwd=xtl_path, check=True)
+    add_cmd = [git2cpp_path, "add", "test_file.txt"]
+    subprocess.run(add_cmd, cwd=tmp_path, check=True)
 
-    commit_cmd = [git2cpp_path, 'commit', '-m', 'my specific commit message']
-    subprocess.run(commit_cmd, cwd=xtl_path, check=True)
+    commit_cmd = [git2cpp_path, "commit", "-m", "my specific commit message"]
+    subprocess.run(commit_cmd, cwd=tmp_path, check=True)
 
     # Create tag with empty message (should create lightweight tag)
-    create_cmd = [git2cpp_path, 'tag', '-m', '', 'v1.0.0']
-    subprocess.run(create_cmd, capture_output=True, cwd=xtl_path, check=True)
+    create_cmd = [git2cpp_path, "tag", "-m", "", "v1.0.0"]
+    subprocess.run(create_cmd, capture_output=True, cwd=tmp_path, check=True)
 
-     # List tag with messages - lightweight tag shows commit message
-    list_cmd = [git2cpp_path, 'tag', '-n', '1']
-    p_list = subprocess.run(list_cmd, capture_output=True, cwd=xtl_path, text=True)
+    # List tag with messages - lightweight tag shows commit message
+    list_cmd = [git2cpp_path, "tag", "-n", "1"]
+    p_list = subprocess.run(list_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_list.returncode == 0
-    assert 'v1.0.0' in p_list.stdout
+    assert "v1.0.0" in p_list.stdout
     # Lightweight tag shows the commit message, not a tag message
-    assert 'my specific commit message' in p_list.stdout
+    assert "my specific commit message" in p_list.stdout
 
 
-def test_tag_multiple_create_and_list(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_tag_multiple_create_and_list(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test creating multiple tags and listing them."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     # Create multiple tags
-    tags = ['v1.0.0', 'v1.0.1', 'v1.1.0', 'v2.0.0']
+    tags = ["v1.0.0", "v1.0.1", "v1.1.0", "v2.0.0"]
     for tag in tags:
-        create_cmd = [git2cpp_path, 'tag', tag]
-        subprocess.run(create_cmd, capture_output=True, cwd=xtl_path, check=True)
+        create_cmd = [git2cpp_path, "tag", tag]
+        subprocess.run(create_cmd, capture_output=True, cwd=tmp_path, check=True)
 
     # List all tags
-    list_cmd = [git2cpp_path, 'tag']
-    p_list = subprocess.run(list_cmd, capture_output=True, cwd=xtl_path, text=True)
+    list_cmd = [git2cpp_path, "tag"]
+    p_list = subprocess.run(list_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_list.returncode == 0
 
     # Verify all tags are in the list
@@ -267,32 +290,33 @@ def test_tag_multiple_create_and_list(xtl_clone, commit_env_config, git2cpp_path
         assert tag in p_list.stdout
 
 
-def test_tag_on_new_commit(xtl_clone, commit_env_config, git2cpp_path, tmp_path):
+def test_tag_on_new_commit(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path
+):
     """Test creating tags on new commits."""
-    assert (tmp_path / "xtl").exists()
-    xtl_path = tmp_path / "xtl"
+    assert (tmp_path / "initial.txt").exists()
 
     # Tag the current commit
-    tag_cmd_1 = [git2cpp_path, 'tag', 'before-change']
-    subprocess.run(tag_cmd_1, cwd=xtl_path, check=True)
+    tag_cmd_1 = [git2cpp_path, "tag", "before-change"]
+    subprocess.run(tag_cmd_1, cwd=tmp_path, check=True)
 
     # Make a new commit
-    file_path = xtl_path / "new_file.txt"
+    file_path = tmp_path / "new_file.txt"
     file_path.write_text("new content")
 
-    add_cmd = [git2cpp_path, 'add', 'new_file.txt']
-    subprocess.run(add_cmd, cwd=xtl_path, check=True)
+    add_cmd = [git2cpp_path, "add", "new_file.txt"]
+    subprocess.run(add_cmd, cwd=tmp_path, check=True)
 
-    commit_cmd = [git2cpp_path, 'commit', '-m', 'new commit']
-    subprocess.run(commit_cmd, cwd=xtl_path, check=True)
+    commit_cmd = [git2cpp_path, "commit", "-m", "new commit"]
+    subprocess.run(commit_cmd, cwd=tmp_path, check=True)
 
     # Tag the new commit
-    tag_cmd_2 = [git2cpp_path, 'tag', 'after-change']
-    subprocess.run(tag_cmd_2, cwd=xtl_path, check=True)
+    tag_cmd_2 = [git2cpp_path, "tag", "after-change"]
+    subprocess.run(tag_cmd_2, cwd=tmp_path, check=True)
 
     # List tags
-    list_cmd = [git2cpp_path, 'tag']
-    p_list = subprocess.run(list_cmd, capture_output=True, cwd=xtl_path, text=True)
+    list_cmd = [git2cpp_path, "tag"]
+    p_list = subprocess.run(list_cmd, capture_output=True, cwd=tmp_path, text=True)
     assert p_list.returncode == 0
-    assert 'before-change' in p_list.stdout
-    assert 'after-change' in p_list.stdout
+    assert "before-change" in p_list.stdout
+    assert "after-change" in p_list.stdout


### PR DESCRIPTION
Fix #109 
Reduce use of ```xtl_clone``` in tests