### PR TITLE
Add codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # git2cpp
 [![GithubActions](https://github.com/QuantStack/git2cpp/actions/workflows/test.yml/badge.svg)](https://github.com/QuantStack/git2cpp/actions/workflows/test.yml)
 [![Documentation Status](http://readthedocs.org/projects/git2cpp/badge/?version=latest)](https://git2cpp.readthedocs.io/en/latest/?badge=latest)
+[![Codecov](https://codecov.io/gh/QuantStack/git2cpp/graph/badge.svg)](https://app.codecov.io/gh/QuantStack/git2cpp)
 
 This is a C++ wrapper of [libgit2](https://libgit2.org/) to provide a command-line interface (CLI)
 to `git` functionality. The intended use is in WebAssembly in-browser terminals (see


### PR DESCRIPTION
Add codecov badge to README so that it looks like this:

<img width="329" height="42" alt="Screenshot 2026-03-10 at 08 25 54" src="https://github.com/user-attachments/assets/f85ed45b-0477-4100-8cbc-f28c259946bb" />

If you click on the badge it takes you to the codecov page so that you can look at the details.