### PR TITLE
Add user-configurable timeout to wasm http requests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ set(GIT2CPP_SRC
     ${GIT2CPP_SOURCE_DIR}/utils/progress.hpp
     ${GIT2CPP_SOURCE_DIR}/utils/terminal_pager.cpp
     ${GIT2CPP_SOURCE_DIR}/utils/terminal_pager.hpp
+    ${GIT2CPP_SOURCE_DIR}/wasm/constants.hpp
     ${GIT2CPP_SOURCE_DIR}/wasm/libgit2_internals.cpp
     ${GIT2CPP_SOURCE_DIR}/wasm/libgit2_internals.hpp
     ${GIT2CPP_SOURCE_DIR}/wasm/response.cpp
@@ -110,6 +111,8 @@ set(GIT2CPP_SRC
     ${GIT2CPP_SOURCE_DIR}/wasm/subtransport.hpp
     ${GIT2CPP_SOURCE_DIR}/wasm/transport.cpp
     ${GIT2CPP_SOURCE_DIR}/wasm/transport.hpp
+    ${GIT2CPP_SOURCE_DIR}/wasm/utils.cpp
+    ${GIT2CPP_SOURCE_DIR}/wasm/utils.hpp
     ${GIT2CPP_SOURCE_DIR}/wrapper/annotated_commit_wrapper.cpp
     ${GIT2CPP_SOURCE_DIR}/wrapper/annotated_commit_wrapper.hpp
     ${GIT2CPP_SOURCE_DIR}/wrapper/branch_wrapper.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ set(GIT2CPP_SRC
     ${GIT2CPP_SOURCE_DIR}/utils/progress.hpp
     ${GIT2CPP_SOURCE_DIR}/utils/terminal_pager.cpp
     ${GIT2CPP_SOURCE_DIR}/utils/terminal_pager.hpp
+    ${GIT2CPP_SOURCE_DIR}/wasm/constants.hpp
     ${GIT2CPP_SOURCE_DIR}/wasm/libgit2_internals.cpp
     ${GIT2CPP_SOURCE_DIR}/wasm/libgit2_internals.hpp
     ${GIT2CPP_SOURCE_DIR}/wasm/response.cpp
@@ -112,6 +113,8 @@ set(GIT2CPP_SRC
     ${GIT2CPP_SOURCE_DIR}/wasm/subtransport.hpp
     ${GIT2CPP_SOURCE_DIR}/wasm/transport.cpp
     ${GIT2CPP_SOURCE_DIR}/wasm/transport.hpp
+    ${GIT2CPP_SOURCE_DIR}/wasm/utils.cpp
+    ${GIT2CPP_SOURCE_DIR}/wasm/utils.hpp
     ${GIT2CPP_SOURCE_DIR}/wrapper/annotated_commit_wrapper.cpp
     ${GIT2CPP_SOURCE_DIR}/wrapper/annotated_commit_wrapper.hpp
     ${GIT2CPP_SOURCE_DIR}/wrapper/branch_wrapper.cpp

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,3 +19,4 @@ html_theme_options = {
     "show_navbar_depth": 2,
 }
 html_title = "git2cpp documentation"
+myst_enable_extensions = ["deflist"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,3 +15,14 @@ please create an issue in the [git2cpp github repository](https://github.com/Qua
 :hidden:
 created/git2cpp
 ```
+
+## Environment variables
+
+`GIT_HTTP_TIMEOUT`
+: In the WebAssembly build, all http(s) requests are limited by a timeout which has a default of 10
+  seconds. To use a different timeout set the `GIT_HTTP_TIMEOUT` environment variable. For example,
+  to set a timeout of 20 seconds use:
+
+  ```bash
+  export GIT_HTTP_TIMEOUT=20
+  ```

--- a/src/wasm/constants.hpp
+++ b/src/wasm/constants.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <string_view>
+
+// Constants used in wasm transport layer.
+// Exposed to non-emscripten builds so that they can be used in help.
+
+// Environment variable for http transport timeout.
+// Must be a positive number as a timeout of 0 will block forever.
+inline constexpr std::string_view WASM_HTTP_TRANSPORT_TIMEOUT_NAME = "GIT_HTTP_TIMEOUT";
+inline constexpr unsigned int WASM_HTTP_TRANSPORT_TIMEOUT_DEFAULT = 10;

--- a/src/wasm/constants.hpp
+++ b/src/wasm/constants.hpp
@@ -8,4 +8,4 @@
 // Environment variable for http transport timeout.
 // Must be a positive number as a timeout of 0 will block forever.
 inline constexpr std::string_view WASM_HTTP_TRANSPORT_TIMEOUT_NAME = "GIT_HTTP_TIMEOUT";
-inline constexpr unsigned int WASM_HTTP_TRANSPORT_TIMEOUT_DEFAULT = 10;
+inline constexpr unsigned int WASM_HTTP_TRANSPORT_TIMEOUT_DEFAULT_S = 10;

--- a/src/wasm/stream.cpp
+++ b/src/wasm/stream.cpp
@@ -44,6 +44,7 @@ EM_JS(
      const char* method,
      const char* content_type_header,
      const char* authorization_header,
+     unsigned long request_timeout_ms,
      size_t buffer_size),
     {
         const url_js = UTF8ToString(url);
@@ -65,6 +66,7 @@ EM_JS(
                 // Should this only be set if using https?  What about CORS via http?
                 xhr.setRequestHeader("Authorization", authorization_header_js);
             }
+            xhr.timeout = request_timeout_ms;
 
             // Cache request info on JavaScript side so that it is available in subsequent calls
             // without having to pass it back and forth to/from C++.
@@ -257,6 +259,7 @@ static int create_request(wasm_http_stream* stream, std::string_view content_hea
         name_for_method(stream->m_service.m_method).c_str(),
         content_header.data(),
         stream->m_subtransport->m_authorization_header.c_str(),
+        stream->m_subtransport->m_request_timeout_ms,
         EMFORGE_BUFSIZE
     );
     return stream->m_request_index;

--- a/src/wasm/stream.cpp
+++ b/src/wasm/stream.cpp
@@ -220,7 +220,7 @@ EM_JS(void, js_warning, (const char* msg), {
     console.warning(msg_js);
 });
 
-EM_JS(size_t, js_write, (int request_index, const char* buffer, size_t buffer_size), {
+EM_JS(int, js_write, (int request_index, const char* buffer, size_t buffer_size), {
     try
     {
         const cache = Module["git2cpp_js_cache"];
@@ -359,7 +359,7 @@ static int read(wasm_http_stream* stream, wasm_http_response& response, bool is_
         &status_text,
         &response_headers
     );
-    if (bytes_read < 0)
+    if (bytes_read == static_cast<size_t>(-1))
     {
         convert_js_to_git_error(stream);
         // Delete const char* allocated in JavaScript.
@@ -551,7 +551,7 @@ int wasm_http_stream_read(git_smart_subtransport_stream* s, char* buffer, size_t
     bool send = true;
     while (send)
     {
-        if (read(stream, response, false) < 0)
+        if (read(stream, response, false) == static_cast<size_t>(-1))
         {
             return -1;  // git error already set.
         }

--- a/src/wasm/stream.cpp
+++ b/src/wasm/stream.cpp
@@ -8,6 +8,7 @@
 #    include <emscripten.h>
 
 #    include "../utils/common.hpp"
+#    include "constants.hpp"
 #    include "response.hpp"
 
 // Buffer size used in transport_smart, hardcoded in libgit2.
@@ -106,7 +107,7 @@ EM_JS(
             // clang-format off
             Module["git2cpp_js_error"] = { name: err.name ?? "", message : err.message ?? "" };
             // clang-format on
-            console.error(err);
+            (err.name == "TimeoutError" ? console.warn : console.error)(err);
             return -1;
         }
     }
@@ -208,7 +209,7 @@ EM_JS(
             // clang-format off
             Module["git2cpp_js_error"] = { name: err.name ?? "", message : err.message ?? "" };
             // clang-format on
-            console.error(err);
+            (err.name == "TimeoutError" ? console.warn : console.error)(err);
             return -1;
         }
     }
@@ -245,7 +246,7 @@ EM_JS(size_t, js_write, (int request_index, const char* buffer, size_t buffer_si
         // clang-format off
         Module["git2cpp_js_error"] = { name: err.name ?? "", message : err.message ?? "" };
         // clang-format on
-        console.error(err);
+        (err.name == "TimeoutError" ? console.warn : console.error)(err);
         return -1;
     }
 });
@@ -271,6 +272,16 @@ static void convert_js_to_git_error(wasm_http_stream* stream)
             GIT_ERROR_HTTP,
             "network error sending request to %s, see the browser console and/or network tab for more details",
             stream->m_unconverted_url.c_str()
+        );
+    }
+    else if (std::string_view(error_str).starts_with("TimeoutError:"))
+    {
+        git_error_set(
+            GIT_ERROR_HTTP,
+            "network request timed out connecting to %s. You can set a longer timeout in seconds using the environment variable %s, the default value is %u seconds.",
+            stream->m_unconverted_url.c_str(),
+            WASM_HTTP_TRANSPORT_TIMEOUT_NAME.data(),
+            WASM_HTTP_TRANSPORT_TIMEOUT_DEFAULT_S
         );
     }
     else

--- a/src/wasm/stream.cpp
+++ b/src/wasm/stream.cpp
@@ -51,6 +51,7 @@ EM_JS(
      const char* method,
      const char* content_type_header,
      const char* authorization_header,
+     unsigned long request_timeout_ms,
      size_t buffer_size),
     {
         const url_js = UTF8ToString(url);
@@ -76,6 +77,7 @@ EM_JS(
             {
                 xhr.setRequestHeader("x-runtime-token", "{#{RUNTIME_TOKEN}#}");
             }
+            xhr.timeout = request_timeout_ms;
 
             // Cache request info on JavaScript side so that it is available in subsequent calls
             // without having to pass it back and forth to/from C++.
@@ -285,6 +287,7 @@ static int create_request(wasm_http_stream* stream, std::string_view content_hea
         name_for_method(stream->m_service.m_method).c_str(),
         content_header.data(),
         stream->m_subtransport->m_authorization_header.c_str(),
+        stream->m_subtransport->m_request_timeout_ms,
         EMFORGE_BUFSIZE
     );
     return stream->m_request_index;

--- a/src/wasm/subtransport.cpp
+++ b/src/wasm/subtransport.cpp
@@ -2,15 +2,16 @@
 
 #    include "subtransport.hpp"
 
+#    include <iostream>
 #    include <regex>
 #    include <sstream>
 
-#    include <emscripten.h>
 #    include <git2/sys/credential.h>
 #    include <git2/sys/remote.h>
 
 #    include "libgit2_internals.hpp"
 #    include "stream.hpp"
+#    include "utils.hpp"
 
 // C functions.
 
@@ -93,6 +94,7 @@ int create_wasm_http_subtransport(git_smart_subtransport** out, git_transport* o
     subtransport->m_owner = owner;
     subtransport->m_base_url = "";
     subtransport->m_credential = nullptr;
+    subtransport->m_request_timeout_ms = get_request_timeout_ms();
 
     *out = &subtransport->m_parent;
     return 0;

--- a/src/wasm/subtransport.hpp
+++ b/src/wasm/subtransport.hpp
@@ -17,7 +17,8 @@ struct wasm_http_subtransport
     // Data stored for reuse on other streams of this transport:
     std::string m_base_url;
     std::string m_authorization_header;
-    git_credential* m_credential;  // libgit2 creates this, we are responsible for deleting it.
+    git_credential* m_credential;        // libgit2 creates this, we are responsible for deleting it.
+    unsigned long m_request_timeout_ms;  // Timeout for http(s) requests in milliseconds.
 };
 
 // git_smart_subtransport_cb

--- a/src/wasm/utils.cpp
+++ b/src/wasm/utils.cpp
@@ -1,0 +1,38 @@
+#ifdef EMSCRIPTEN
+
+#    include "utils.hpp"
+
+#    include <termcolor/termcolor.hpp>
+
+#    include "constants.hpp"
+
+unsigned long get_request_timeout_ms()
+{
+    double timeout_seconds = WASM_HTTP_TRANSPORT_TIMEOUT_DEFAULT;
+    auto env_var = std::getenv(WASM_HTTP_TRANSPORT_TIMEOUT_NAME.data());
+    if (env_var != nullptr)
+    {
+        try
+        {
+            auto value = std::stod(env_var);
+            if (value <= 0)
+            {
+                throw std::runtime_error("negative or zero");
+            }
+            timeout_seconds = value;
+        }
+        catch (std::exception& e)
+        {
+            // Catch failures from (1) stod and (2) timeout <= 0.
+            // Print warning and use default value.
+            std::cout << termcolor::yellow << "Warning: environment variable "
+                      << WASM_HTTP_TRANSPORT_TIMEOUT_NAME
+                      << " must be a positive number of seconds, using default value of "
+                      << WASM_HTTP_TRANSPORT_TIMEOUT_DEFAULT << " seconds instead." << termcolor::reset
+                      << std::endl;
+        }
+    }
+    return 1000 * timeout_seconds;
+}
+
+#endif  // EMSCRIPTEN

--- a/src/wasm/utils.cpp
+++ b/src/wasm/utils.cpp
@@ -8,16 +8,16 @@
 
 unsigned long get_request_timeout_ms()
 {
-    double timeout_seconds = WASM_HTTP_TRANSPORT_TIMEOUT_DEFAULT;
+    double timeout_seconds = WASM_HTTP_TRANSPORT_TIMEOUT_DEFAULT_S;
     auto env_var = std::getenv(WASM_HTTP_TRANSPORT_TIMEOUT_NAME.data());
     if (env_var != nullptr)
     {
         try
         {
             auto value = std::stod(env_var);
-            if (value <= 0)
+            if (value < 1e-3)  // Must be at least 1 ms.
             {
-                throw std::runtime_error("negative or zero");
+                throw std::runtime_error("");  // Caught below.
             }
             timeout_seconds = value;
         }
@@ -28,7 +28,7 @@ unsigned long get_request_timeout_ms()
             std::cout << termcolor::yellow << "Warning: environment variable "
                       << WASM_HTTP_TRANSPORT_TIMEOUT_NAME
                       << " must be a positive number of seconds, using default value of "
-                      << WASM_HTTP_TRANSPORT_TIMEOUT_DEFAULT << " seconds instead." << termcolor::reset
+                      << WASM_HTTP_TRANSPORT_TIMEOUT_DEFAULT_S << " seconds instead." << termcolor::reset
                       << std::endl;
         }
     }

--- a/src/wasm/utils.hpp
+++ b/src/wasm/utils.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#ifdef EMSCRIPTEN
+
+// Get wasm http request timeout in milliseconds from environment variable or default value.
+unsigned long get_request_timeout_ms();
+
+#endif  // EMSCRIPTEN

--- a/test/test_clone.py
+++ b/test/test_clone.py
@@ -1,5 +1,6 @@
 import pytest
 import subprocess
+from .conftest import GIT2CPP_TEST_WASM
 
 xtl_url = "https://github.com/xtensor-stack/xtl.git"
 
@@ -144,3 +145,63 @@ def test_clone_gitlab(git2cpp_path, tmp_path, run_in_tmp_path, protocol):
     assert p_status.returncode == 0
     assert "On branch main" in p_status.stdout
     assert "Your branch is up to date with 'origin/main'" in p_status.stdout
+
+
+@pytest.mark.skipif(not GIT2CPP_TEST_WASM, reason="Only test in WebAssembly")
+def test_clone_timeout(git2cpp_path, tmp_path, run_in_tmp_path):
+    # Set very short timeout.
+    subprocess.run(["export", "GIT_HTTP_TIMEOUT=0.001"], check=True)
+
+    # Check timeout is set.
+    check_env_cmd = ["env"]
+    p_check_env = subprocess.run(check_env_cmd, capture_output=True, cwd=tmp_path, text=True)
+    assert "GIT_HTTP_TIMEOUT=0.001" in p_check_env.stdout
+
+    # Clone fails with timeout.
+    clone_cmd = [git2cpp_path, "clone", xtl_url]
+    p_clone = subprocess.run(clone_cmd, capture_output=True, cwd=tmp_path, text=True)
+    assert p_clone.returncode != 0
+    assert "network request timed out connecting to" in p_clone.stderr
+    assert (
+        "set a longer timeout in seconds using the environment variable GIT_HTTP_TIMEOUT"
+        in p_clone.stderr
+    )
+
+    # Set more reasonable timeout.
+    subprocess.run(["export", "GIT_HTTP_TIMEOUT=10"], check=True)
+
+    # Check timeout is set.
+    p_check_env = subprocess.run(check_env_cmd, capture_output=True, cwd=tmp_path, text=True)
+    assert "GIT_HTTP_TIMEOUT=10" in p_check_env.stdout
+
+    # Clone succeeds.
+    clone_cmd = [git2cpp_path, "clone", xtl_url]
+    p_clone = subprocess.run(clone_cmd, capture_output=True, cwd=tmp_path, text=True)
+    assert p_clone.returncode == 0
+
+    assert (tmp_path / "xtl").exists()
+    assert (tmp_path / "xtl/include").exists()
+
+
+@pytest.mark.skipif(not GIT2CPP_TEST_WASM, reason="Only test in WebAssembly")
+def test_clone_negative_timeout_ignored(git2cpp_path, tmp_path, run_in_tmp_path):
+    # Set negative timeout.
+    subprocess.run(["export", "GIT_HTTP_TIMEOUT=-1"], check=True)
+
+    # Check timeout is set.
+    check_env_cmd = ["env"]
+    p_check_env = subprocess.run(check_env_cmd, capture_output=True, cwd=tmp_path, text=True)
+    assert "GIT_HTTP_TIMEOUT=-1" in p_check_env.stdout
+
+    # Clone succeeds, ignoring invalid timeout.
+    clone_cmd = [git2cpp_path, "clone", xtl_url]
+    p_clone = subprocess.run(clone_cmd, capture_output=True, cwd=tmp_path, text=True)
+    assert p_clone.returncode == 0
+
+    assert (tmp_path / "xtl").exists()
+    assert (tmp_path / "xtl/include").exists()
+
+    assert (
+        "environment variable GIT_HTTP_TIMEOUT must be a positive number of seconds"
+        in p_clone.stdout
+    )


### PR DESCRIPTION
WIP to add a timeout to wasm http requests. Such requests are synchronous blocking requests so we cannot obtain any feedback to present to the user whilst they are underway, and we have to wait until the corresponding http reply is received in full. These requests can take a long time fi they are clones of a large repo, as lots of data needs to be transferred back to us and usually this is a two-step return as it has to be via a CORS proxy. In the event of the request failing, if there isn't a timeout then the operation will block forever and `cockle` will be unresponsive forever. Note that this is the stage that occurs before the returned data is processed for which we do have progress reported to the user.

Ideally we'd use an asynchronous non-blocking request for this and it is part of our long term plan to implement asynchronous emscripten-forge terminal and kernel packages, but this is not yet available and is non-trivial to implement now.

Here there is a default timeout of 10 seconds (this is TBD really) and it can be overridden by the user via an environment variable:
```bash
export GIT_HTTP_TIMEOUT=20
```

This is a WIP as there is more to do:

- [x] test downstream
- [x] decide on sensible default
- [x] add better documentation in the help
- [x] in the event of a request timing out print useful information to the user to tell them that they can make the timeout longer
- [x] add tests