### PR TITLE
Fix cursor showing and hiding

### DIFF
--- a/src/utils/input_output.cpp
+++ b/src/utils/input_output.cpp
@@ -1,19 +1,39 @@
 #include "input_output.hpp"
 
+#include <iostream>
+
 #include "ansi_code.hpp"
 
 // OS-specific libraries.
 #include <sys/ioctl.h>
 
+unsigned int cursor_hider::s_scope_count = 0;
+
 cursor_hider::cursor_hider(bool hide /* = true */)
     : m_hide(hide)
 {
-    std::cout << (m_hide ? ansi_code::hide_cursor : ansi_code::show_cursor);
+    s_scope_count++;
+    write_ansi_code(m_hide);
 }
 
 cursor_hider::~cursor_hider()
 {
-    std::cout << (m_hide ? ansi_code::show_cursor : ansi_code::hide_cursor);
+    s_scope_count--;
+
+    if (s_scope_count == 0)
+    {
+        // Ensure cursor is visible when git2cpp exits.
+        write_ansi_code(false);
+    }
+    else
+    {
+        write_ansi_code(!m_hide);
+    }
+}
+
+void cursor_hider::write_ansi_code(bool hide)
+{
+    std::cout << (hide ? ansi_code::hide_cursor : ansi_code::show_cursor);
 }
 
 alternative_buffer::alternative_buffer()

--- a/src/utils/input_output.hpp
+++ b/src/utils/input_output.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <stack>
-
 #include "common.hpp"
 
 // OS-specific libraries.

--- a/src/utils/input_output.hpp
+++ b/src/utils/input_output.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <iostream>
+#include <stack>
 
 #include "common.hpp"
 
@@ -22,7 +22,11 @@ public:
 
 private:
 
+    void write_ansi_code(bool hide);
+
     bool m_hide;
+
+    static unsigned int s_scope_count;
 };
 
 // Scope object to use alternative output buffer for


### PR DESCRIPTION
The cursor showing and hiding logic that I previously implemented via the `cursor_hider` scope object was buggy in that it could end up leaving the cursor hidden at the end of a `git2cpp` command. This would happen, for example, using a `prompt_input` which ensures that the cursor is enabled when the prompt is shown and then hides it at the end. The solution, in the presence of potentially nested `cursor_hider` objects, is to keep a static count of the number of active scope objects and ensure the cursor is shown when this goes down to zero.

It does introduce a static variable which isn't ideal but it is only a single `unsigned int`.

This is very hard to test, so I am not doing so in CI but I have tested it manually in both macos and wasm builds.