### PR TITLE
Add wasm test that input prompt using line not character buffering for stdin

### DIFF
--- a/.github/workflows/test-wasm.yml
+++ b/.github/workflows/test-wasm.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/test/conftest_wasm.py
+++ b/test/conftest_wasm.py
@@ -34,6 +34,7 @@ def pytest_ignore_collect(collection_path: pathlib.Path) -> bool:
         "test_revlist.py",
         "test_revparse.py",
         "test_rm.py",
+        "test_showref.py",
         "test_stash.py",
         "test_status.py",
         "test_tag.py",
@@ -46,7 +47,7 @@ def run_web_server():
         cwd = pathlib.Path(__file__).parent.parent / "wasm/test"
         proc = subprocess.Popen(["npm", "run", "serve"], stdout=f, stderr=f, cwd=cwd)
         # Wait a bit until server ready to receive connections.
-        time.sleep(0.5)
+        time.sleep(1)
         yield
         proc.terminate()
 

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -2,6 +2,8 @@ import subprocess
 
 import pytest
 
+from .conftest import GIT2CPP_TEST_WASM
+
 
 @pytest.mark.parametrize("all_flag", ["", "-A", "--all", "--no-ignore-removal"])
 def test_commit(commit_env_config, git2cpp_path, tmp_path, all_flag):
@@ -33,10 +35,20 @@ def test_commit(commit_env_config, git2cpp_path, tmp_path, all_flag):
     assert "mook_file" not in p_status_2.stdout
 
 
-@pytest.mark.parametrize("commit_msg", ["Added file", ""])
+@pytest.mark.parametrize(
+    "commit_msg_in,commit_msg_out",
+    [
+        ("Added file", "Added file"),
+        ("", ""),
+        ("ab\x7fc", "ac"),  # Check deletes previous character to prove using stdin line buffering
+    ],
+)
 def test_commit_message_via_stdin(
-    commit_env_config, git2cpp_path, tmp_path, run_in_tmp_path, commit_msg
+    commit_env_config, git2cpp_path, tmp_path, run_in_tmp_path, commit_msg_in, commit_msg_out
 ):
+    if not GIT2CPP_TEST_WASM and commit_msg_in != commit_msg_out:
+        pytest.skip("Skip stdin delete test if not using webassembly")
+
     cmd = [git2cpp_path, "init", "."]
     p_init = subprocess.run(cmd)
     assert p_init.returncode == 0
@@ -48,9 +60,11 @@ def test_commit_message_via_stdin(
     assert p_add.returncode == 0
 
     cmd_commit = [git2cpp_path, "commit"]
-    p_commit = subprocess.run(cmd_commit, text=True, capture_output=True, input=commit_msg)
+    p_commit = subprocess.run(
+        cmd_commit, text=True, capture_output=True, input=commit_msg_in + "\n"
+    )
 
-    if commit_msg == "":
+    if commit_msg_out == "":
         # No commit message
         assert p_commit.returncode != 0
         assert "Aborting, no commit message specified" in p_commit.stderr
@@ -66,4 +80,4 @@ def test_commit_message_via_stdin(
         assert "commit" in lines[0]
         assert "Author:" in lines[1]
         assert "Date" in lines[2]
-        assert commit_msg in lines[4]
+        assert commit_msg_out in lines[4]

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -30,6 +30,7 @@ def test_status_new_file(repo_init_with_commit, git2cpp_path, tmp_path, short_fl
     if long_flag != "":
         cmd.append(long_flag)
     p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True, check=True)
+    p.stdout = strip_ansi_colours(p.stdout)
 
     if (long_flag == "--long") or ((long_flag == "") & (short_flag == "")):
         assert "On branch main" in p.stdout
@@ -72,6 +73,7 @@ def test_status_add_file(repo_init_with_commit, git2cpp_path, tmp_path, short_fl
         cmd_status.append(long_flag)
     p_status = subprocess.run(cmd_status, capture_output=True, cwd=tmp_path, text=True)
     assert p_status.returncode == 0
+    p_status.stdout = strip_ansi_colours(p_status.stdout)
 
     if (long_flag == "--long") or ((long_flag == "") & (short_flag == "")):
         assert "Changes to be committed" in p_status.stdout
@@ -144,6 +146,7 @@ def test_status_rename_detection(repo_init_with_commit, git2cpp_path, tmp_path, 
         cmd_status.append(short_flag)
     p = subprocess.run(cmd_status, capture_output=True, cwd=tmp_path, text=True)
     assert p.returncode == 0
+    p.stdout = strip_ansi_colours(p.stdout)
 
     # Should show as renamed, not as deleted + new file
     assert "initial.txt -> initial_renamed.txt" in p.stdout
@@ -223,6 +226,8 @@ def test_status_typechange(repo_init_with_commit, git2cpp_path, tmp_path, short_
     p = subprocess.run(cmd_status, capture_output=True, cwd=tmp_path, text=True)
 
     assert p.returncode == 0
+    p.stdout = strip_ansi_colours(p.stdout)
+
     # Should show typechange in unstaged changes
     if short_flag == "-s":
         assert " T " in p.stdout
@@ -295,6 +300,8 @@ def test_status_ahead_of_upstream(
     p = subprocess.run(cmd_status, capture_output=True, cwd=clone_path, text=True)
 
     assert p.returncode == 0
+    p.stdout = strip_ansi_colours(p.stdout)
+
     if short_flag == "-s":
         if branch_flag == "-b":
             assert "...origin/main" in p.stdout
@@ -341,6 +348,8 @@ def test_status_with_branch_and_tracking(
     p = subprocess.run(cmd_status, capture_output=True, cwd=clone_path, text=True)
 
     assert p.returncode == 0
+    p.stdout = strip_ansi_colours(p.stdout)
+
     if short_flag == "-s":
         assert "## main" in p.stdout  # "main" locally, but "master" in the CI
         assert "[ahead 1]" in p.stdout


### PR DESCRIPTION
The correct handling in WebAssembly of the input prompt used for commit messages (issue #44) was fixed in `cockle` in jupyterlite/cockle#309. This PR adds a test to confirm the fix by using a backspace character in the input prompt to delete the previous character, thus confirming that stdin is using line buffering not individual character buffering.

The new test is disabled if not running in WebAssembly. It already worked correctly in a manual test but running it via python's `subprocess.run` doesn't work without us using something more complicated like an input pipe to send the stdin characters, and that approach cannot work in WebAssembly so we'd have to implement some new workaround and it is not worth the effort.

Closes #44.