### PR TITLE
Improve `test_merge_conflict` via new `prompt_yes_or_no`

### DIFF
--- a/src/subcommand/merge_subcommand.cpp
+++ b/src/subcommand/merge_subcommand.cpp
@@ -7,6 +7,7 @@
 #include <git2/types.h>
 #include <termcolor/termcolor.hpp>
 
+#include "../utils/input_output.hpp"
 #include "../wrapper/status_wrapper.hpp"
 
 merge_subcommand::merge_subcommand(const libgit2_object&, CLI::App& app)
@@ -181,10 +182,8 @@ void merge_subcommand::run()
 
             std::cout << "Warning: 'merge --abort' is not implemented yet. A 'reset --hard HEAD' will be executed."
                       << std::endl;
-            std::cout << "Do you want to continue [y/N] ?" << std::endl;
-            std::string answer;
-            std::cin >> answer;
-            if (answer == "y")
+            auto answer = prompt_yes_or_no("Do you want to continue [y/N] ? ", false);
+            if (answer)
             {
                 repo.state_cleanup();
                 index.conflict_cleanup();

--- a/src/utils/input_output.cpp
+++ b/src/utils/input_output.cpp
@@ -94,3 +94,25 @@ std::string prompt_input(const std::string_view prompt, bool echo /* = true */)
     // Maybe sanitise input, removing escape codes?
     return input;
 }
+
+bool prompt_yes_or_no(const std::string_view prompt, bool default_return)
+{
+    while (true)
+    {
+        auto input = prompt_input(prompt);
+        if (input.empty())
+        {
+            return default_return;
+        }
+        auto first_char = std::tolower(input.front());
+        if (first_char == 'y')
+        {
+            return true;
+        }
+        else if (first_char == 'n')
+        {
+            return false;
+        }
+        // Repeat prompt.
+    }
+}

--- a/src/utils/input_output.hpp
+++ b/src/utils/input_output.hpp
@@ -62,3 +62,9 @@ private:
 // stdin from the user.  The `echo` argument controls whether stdin is echoed
 // to stdout, use `false` for passwords.
 std::string prompt_input(const std::string_view prompt, bool echo = true);
+
+// Display a prompt on stdout and accept a yes or no answer on stdin.
+// Return true if the first character on stdin is 'y' or 'Y', false if it is
+// 'n' or 'N', or default_return if the input is empty which occurs if the user
+// presses enter only. Otherwise the input is ambiguous so repeat the prompt.
+bool prompt_yes_or_no(const std::string_view prompt, bool default_return);

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -52,7 +52,7 @@ def commit_env_config(monkeypatch):
 
 
 @pytest.fixture
-def repo_init_with_commit(commit_env_config, git2cpp_path, tmp_path, run_in_tmp_path):
+def repo_init_with_commit(commit_env_config, git2cpp_path, tmp_path):
     cmd_init = [git2cpp_path, "init", ".", "-b", "main"]
     p_init = subprocess.run(cmd_init, capture_output=True, cwd=tmp_path, text=True)
     assert p_init.returncode == 0

--- a/test/conftest_wasm.py
+++ b/test/conftest_wasm.py
@@ -46,7 +46,7 @@ def run_web_server():
         cwd = pathlib.Path(__file__).parent.parent / "wasm/test"
         proc = subprocess.Popen(["npm", "run", "serve"], stdout=f, stderr=f, cwd=cwd)
         # Wait a bit until server ready to receive connections.
-        time.sleep(0.3)
+        time.sleep(0.5)
         yield
         proc.terminate()
 

--- a/test/test_fixtures.py
+++ b/test/test_fixtures.py
@@ -37,3 +37,39 @@ def test_env_vars():
         assert git_lines == ["GIT_CORS_PROXY=http://localhost:8881/"]
     else:
         assert git_lines == []
+
+
+def test_repo_init_with_commit(repo_init_with_commit, git2cpp_path, tmp_path):
+    assert (tmp_path / "initial.txt").exists()
+    assert (tmp_path / "initial.txt").is_file()
+    assert (tmp_path / "initial.txt").read_text() == "initial"
+
+    git_dir = tmp_path / ".git"
+    assert git_dir.exists()
+    assert git_dir.is_dir()
+
+    assert sorted(tmp_path.iterdir()) == [
+        git_dir,
+        tmp_path / "initial.txt",
+    ]
+
+    assert sorted(git_dir.iterdir()) == [
+        git_dir / "HEAD",
+        git_dir / "config",
+        git_dir / "description",
+        git_dir / "hooks",
+        git_dir / "index",
+        git_dir / "info",
+        git_dir / "logs",
+        git_dir / "objects",
+        git_dir / "refs",
+    ]
+
+    cmd = [git2cpp_path, "log"]
+    p = subprocess.run(cmd, capture_output=True, cwd=tmp_path, text=True)
+    assert p.returncode == 0
+    lines = p.stdout.splitlines()
+    assert "commit" in lines[0]
+    assert lines[1].startswith("Author:")
+    assert lines[2].startswith("Date:")
+    assert "Initial commit" in lines[4]

--- a/test/test_merge.py
+++ b/test/test_merge.py
@@ -97,8 +97,21 @@ def test_merge_commit(repo_init_with_commit, commit_env_config, git2cpp_path, tm
     assert p_merge_2.stdout == "Already up-to-date\n"
 
 
-@pytest.mark.parametrize("flag", ["--abort", "--quit", "--continue"])
-def test_merge_conflict(repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path, flag):
+@pytest.mark.parametrize(
+    "flag, abort_input",
+    [
+        ("--abort", "y"),
+        ("--abort", "Y"),
+        ("--abort", "n"),
+        ("--abort", "N"),
+        ("--abort", ""),
+        ("--quit", None),
+        ("--continue", None),
+    ],
+)
+def test_merge_conflict(
+    repo_init_with_commit, commit_env_config, git2cpp_path, tmp_path, flag, abort_input
+):
     assert (tmp_path / "initial.txt").exists()
 
     checkout_cmd = [git2cpp_path, "checkout", "-b", "foregone"]
@@ -140,18 +153,18 @@ def test_merge_conflict(repo_init_with_commit, commit_env_config, git2cpp_path, 
 
     flag_cmd = [git2cpp_path, "merge", flag]
     if flag == "--abort":
-        for answer in {"y", ""}:
-            p_abort = subprocess.run(
-                flag_cmd, input=answer, capture_output=True, cwd=tmp_path, text=True
-            )
-            assert p_abort.returncode == 0
-            assert (tmp_path / "mook_file.txt").exists()
-            text = (tmp_path / "mook_file.txt").read_text()
-            if answer == "y":
-                assert "BLA" in text
-                assert "bla" not in text
-            else:
-                assert "Abort." in p_abort.stdout
+        p_abort = subprocess.run(
+            flag_cmd, input=abort_input, capture_output=True, cwd=tmp_path, text=True
+        )
+
+        assert p_abort.returncode == 0
+        assert (tmp_path / "mook_file.txt").exists()
+        text = (tmp_path / "mook_file.txt").read_text()
+        if abort_input.lower() == "y":
+            assert "BLA" in text
+            assert "bla" not in text
+        else:
+            assert "Abort." in p_abort.stdout
 
     elif flag == "--quit":
         pass

--- a/test/test_merge.py
+++ b/test/test_merge.py
@@ -98,7 +98,7 @@ def test_merge_commit(repo_init_with_commit, commit_env_config, git2cpp_path, tm
 
 
 @pytest.mark.parametrize(
-    "flag, abort_input",
+    "flag,abort_input",
     [
         ("--abort", "y"),
         ("--abort", "Y"),

--- a/wasm/test/src/index.ts
+++ b/wasm/test/src/index.ts
@@ -47,7 +47,10 @@ async function shellRun(
 
   if (input !== undefined && input !== null) {
     async function delayThenStdin(): Promise<void> {
-      const chars = input! + '\x04';  // EOT
+      let chars = input!;
+      if (!chars.endsWith('\n')) {
+        chars += '\n';
+      }
       await delay(100);
       for (const char of chars) {
         await shell.input(char);


### PR DESCRIPTION
This PR implements a new helper function `prompt_yes_or_no` which prompts the user for a yes or no answer and uses a default if the user just presses return, and repeats the prompt if the user's response is not clear. This is used by `git2cpp merge --abort` for the prompt to continue or not.

As part of this I have refactored `test_merge_conflict` to explicitly test all of the possibilities, and I believe I have made the test less flaky than it used to be.