### PR TITLE
Fix display of bold in docs

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,3 @@
+span.git2cpp-bold {
+    font-weight: bold;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,8 @@ extensions = [
 
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
-html_static_path = []
+html_css_files = ["custom.css"]
+html_static_path = ["_static"]
 html_theme = "sphinx_book_theme"
 html_theme_options = {
     "github_url": "https://github.com/QuantStack/git2cpp",

--- a/docs/create_markdown.py
+++ b/docs/create_markdown.py
@@ -19,6 +19,12 @@ def sanitise_line(line):
     line = line.replace(r"<", r"&lt;")
     line = line.replace(r">", r"&gt;")
 
+    # Replace ansi style codes with <span> elements, only bold is displayed.
+    # Colour codes are converted to empty <span> elements to match the number of </span>.
+    line = line.replace("\x1b[1m", r"<span class=git2cpp-bold>")
+    line = line.replace("\x1b[0m", r"</span>")
+    line = re.sub(r"\x1b\[[^m]+m", r"<span>", line)
+
     # If there are whitespace characters at the start of the line, replace the first with an &nbsp
     # so that it is not discarded by the markdown parser used by the parsed-literal directive.
     line = re.sub(r"^\s", r"&nbsp;", line)

--- a/src/subcommand/reset_subcommand.cpp
+++ b/src/subcommand/reset_subcommand.cpp
@@ -21,7 +21,7 @@ reset_subcommand::reset_subcommand(const libgit2_object&, CLI::App& app)
     sub->add_flag(
         "--soft",
         m_soft_flag,
-        "Leave your working tree files and the index unchanged. For example, if you have no staged changes, you can use"
+        "Leave your working tree files and the index unchanged. For example, if you have no staged changes, you can use "
             + ansi_code::bold + "git reset --soft HEAD~5" + ansi_code::reset + "; " + ansi_code::bold
             + "git commit" + ansi_code::reset
             + " to combine the last 5 commits into 1 commit. This works even with changes in the working tree, which are left untouched, but such usage can lead to confusion."

--- a/src/subcommand/stash_subcommand.cpp
+++ b/src/subcommand/stash_subcommand.cpp
@@ -43,7 +43,7 @@ stash_subcommand::stash_subcommand(const libgit2_object&, CLI::App& app)
     auto* pop = stash->add_subcommand(
         "pop",
         "Remove a single stashed state from the stash list and apply it on top of the current working tree state, i.e., do the inverse operation of "
-            + ansi_code::bold + "git stash push.\n" + ansi_code::reset
+            + ansi_code::bold + "git stash push" + ansi_code::reset + ".\n"
     );
     auto* apply = stash->add_subcommand(
         "apply",


### PR DESCRIPTION
Fix the use of `ansi_code::bold` and `ansi_code::reset` in HTML docs. These now map across to `<span>` elements using CSS of `font-weight: bold`.